### PR TITLE
Prevent false positives when test fails to start because of an error

### DIFF
--- a/lua/neotest-java/core/result_builder.lua
+++ b/lua/neotest-java/core/result_builder.lua
@@ -193,6 +193,11 @@ function ResultBuilder.build_results(spec, result, tree)
 					results[node_data.id] = {
 						status = "skipped",
 					}
+				elseif test_case.error then
+					results[node_data.id] = {
+						status = "failed",
+						short = test_case.error._attr.message,
+					}
 				elseif test_case.failure then
 					results[node_data.id] = {
 						status = "failed",

--- a/tests/core/result_builder_spec.lua
+++ b/tests/core/result_builder_spec.lua
@@ -55,6 +55,43 @@ describe("ResultBuilder", function()
 		assert_equal_ignoring_whitespaces(expected, actual)
 	end)
 
+	async.it("builds the results for a maven test that has an error at start", function()
+		--given
+		local runSpec = {
+			cwd = get_current_dir() .. "tests/fixtures/maven-demo",
+			context = {
+				project_type = "maven",
+				test_class_path = "com.example.ExampleTest",
+			},
+		}
+
+		local strategyResult = {
+			code = 0,
+			output = "output",
+		}
+
+		local file_path = get_current_dir() .. "tests/fixtures/maven-demo/src/test/java/com/example/ErroneousTest.java"
+		local tree = plugin.discover_positions(file_path)
+
+		--when
+		local results = plugin.results(runSpec, strategyResult, tree)
+
+		--then
+		local actual = table_to_string(results)
+		local expected = [[
+      {
+        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ErroneousTest.java::shouldFailOnError"] = {
+          short = "Error creating bean with name 'com.example.ErroneousTest': Injection of autowired dependencies failed",
+          status = "failed"
+        }
+      }
+    ]]
+
+		expected = expected:gsub("{{current_dir}}", get_current_dir())
+
+		assert_equal_ignoring_whitespaces(expected, actual)
+	end)
+
 	async.it("builds the results for gradle", function()
 		--given
 		local runSpec = {

--- a/tests/fixtures/maven-demo/src/test/java/com/example/ErroneousTest.java
+++ b/tests/fixtures/maven-demo/src/test/java/com/example/ErroneousTest.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.example.demo.DemoApplication;
+
+@SpringBootTest(classes = { DemoApplication.class })
+public class ErroneousTest {
+    @Value("${foo.property}") String requiredProperty;
+
+    @Test
+    void shouldFailOnError(){
+      assertEquals("test", requiredProperty);
+    }
+}


### PR DESCRIPTION
I noticed that the adapter will show tests succeeded if an error occurred when trying to start a test but there is an error. In this case in the xml file there will be an `<error>` tag instead of a `<failure>` tag. Because of this the failure wouldn't be caught and so it would go to the else and show it as succeeding. This is to fix this issue.