### PR TITLE
fix: use default configuration when not specified

### DIFF
--- a/tests/core/spec_builder_spec.lua
+++ b/tests/core/spec_builder_spec.lua
@@ -9,7 +9,10 @@ end
 describe("SpecBuilder", function()
 	before_each(function()
 		-- set config
-		plugin.ignore_wrapper = false
+		local config = {
+			ignore_wrapper = false,
+		}
+		plugin.config = config
 	end)
 
 	async.it("builds spec for one method in unit test class with maven", function()
@@ -209,7 +212,7 @@ describe("SpecBuilder", function()
 		}
 
 		-- config
-		plugin.ignore_wrapper = true
+		plugin.config.ignore_wrapper = true
 
 		-- when
 		local actual = plugin.build_spec(args)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -1,0 +1,27 @@
+describe("NeotestJava plugin", function()
+	it("should init default configuration", function()
+		-- given
+		local expected_config = {
+			ignore_wrapper = false,
+		}
+
+		-- when
+		local plugin = require("neotest-java")
+
+		-- then
+		assert.are.same(expected_config, plugin.config)
+	end)
+
+	it("should init with empty configuration", function()
+		-- given
+		local expected_config = {
+			ignore_wrapper = false,
+		}
+
+		-- when
+		local plugin = require("neotest-java")({})
+
+		-- then
+		assert.are.same(expected_config, plugin.config)
+	end)
+end)


### PR DESCRIPTION
I found out that it was not using the default configuration when it was not specified.

Example:
```lua
require("neotest").setup({
  adapters = {
    require("neotest-java"),
  }
})
``` 

This PR fix it.