### PR TITLE
feat: added classes as namespaces to the treesitter query

### DIFF
--- a/lua/neotest-java/core/positions_discoverer.lua
+++ b/lua/neotest-java/core/positions_discoverer.lua
@@ -8,7 +8,7 @@ PositionsDiscoverer = {}
 ---@return neotest.Tree | nil
 function PositionsDiscoverer:discover_positions(file_path)
 	local query = [[
-      ;; @Test function
+      ;; @Test and @ParameterizedTest functions
       (method_declaration
         (modifiers
           (marker_annotation
@@ -18,6 +18,7 @@ function PositionsDiscoverer:discover_positions(file_path)
         )
         name: (identifier) @test.name
       ) @test.definition
+
     ]]
 
 	return lib.treesitter.parse_positions(file_path, query)

--- a/lua/neotest-java/core/positions_discoverer.lua
+++ b/lua/neotest-java/core/positions_discoverer.lua
@@ -8,6 +8,12 @@ PositionsDiscoverer = {}
 ---@return neotest.Tree | nil
 function PositionsDiscoverer:discover_positions(file_path)
 	local query = [[
+
+       ;; Test class
+        (class_declaration
+          name: (identifier) @namespace.name
+        ) @namespace.definition
+
       ;; @Test and @ParameterizedTest functions
       (method_declaration
         (modifiers
@@ -21,7 +27,7 @@ function PositionsDiscoverer:discover_positions(file_path)
 
     ]]
 
-	return lib.treesitter.parse_positions(file_path, query)
+	return lib.treesitter.parse_positions(file_path, query, { nested_namespaces = true })
 end
 
 return PositionsDiscoverer

--- a/lua/neotest-java/init.lua
+++ b/lua/neotest-java/init.lua
@@ -32,7 +32,6 @@ NeotestJavaAdapter = {
 		elseif NeotestJavaAdapter.project_type == "gradle" then
 			ignore_wrapper = vim.fn.filereadable("gradlew") == 1
 		end
-		print("ignore_wrapper: " .. tostring(ignore_wrapper))
 		return ignore_wrapper
 	end,
 }

--- a/tests/core/positions_discoverer_spec.lua
+++ b/tests/core/positions_discoverer_spec.lua
@@ -2,14 +2,12 @@ local async = require("nio").tests
 local plugin = require("neotest-java")
 local Tree = require("neotest.types").Tree
 
-local function getCurrentDir()
-	return vim.fn.fnamemodify(vim.fn.expand("%:p:h"), ":p")
-end
+local current_dir = vim.fn.expand("%:p:h") .. "/"
 
 describe("PositionsDiscoverer", function()
 	async.it("should discover test method names", function()
 		-- given
-		local file_path = getCurrentDir() .. "tests/fixtures/Test.java"
+		local file_path = current_dir .. "tests/fixtures/Test.java"
 
 		-- when
 		local actual = plugin.discover_positions(file_path)
@@ -25,5 +23,17 @@ describe("PositionsDiscoverer", function()
 		assert.equals(actual_list[3][1].name, "shouldFindThis2")
 		assert.equals(actual_list[4][1].name, "shouldFindThis3")
 		assert.equals(actual_list[5][1].name, "shouldFindThis4")
+	end)
+
+	async.it("should discover nested tests", function()
+		-- given
+		local file_path = current_dir .. "tests/fixtures/SomeNestedTest.java"
+
+		-- when
+		local actual = plugin.discover_positions(file_path)
+
+		-- then
+		local test_name = actual:to_list()[2][1].name
+		assert.equals(test_name, "someTest")
 	end)
 end)

--- a/tests/core/positions_discoverer_spec.lua
+++ b/tests/core/positions_discoverer_spec.lua
@@ -15,14 +15,14 @@ describe("PositionsDiscoverer", function()
 		-- then
 		local actual_list = actual:to_list()
 
-		-- for debugging
-		-- print(actual)
-		-- print("value: " .. actual_list[3][1].name)
+		assert.equals("shouldFindThis1", actual_list[2][2][1].name)
+		assert.equals("shouldFindThis2", actual_list[2][3][1].name)
+		assert.equals("shouldFindThis3", actual_list[2][4][1].name)
+		assert.equals("shouldFindThis4", actual_list[2][5][1].name)
 
-		assert.equals(actual_list[2][1].name, "shouldFindThis1")
-		assert.equals(actual_list[3][1].name, "shouldFindThis2")
-		assert.equals(actual_list[4][1].name, "shouldFindThis3")
-		assert.equals(actual_list[5][1].name, "shouldFindThis4")
+		-- should find 4 tests
+		local actual_count = #actual:children()[1]:children()
+		assert.equals(4, actual_count)
 	end)
 
 	async.it("should discover nested tests", function()
@@ -33,7 +33,7 @@ describe("PositionsDiscoverer", function()
 		local actual = plugin.discover_positions(file_path)
 
 		-- then
-		local test_name = actual:to_list()[2][1].name
+		local test_name = actual:to_list()[2][2][2][1].name
 		assert.equals(test_name, "someTest")
 	end)
 end)

--- a/tests/core/positions_discoverer_spec.lua
+++ b/tests/core/positions_discoverer_spec.lua
@@ -33,7 +33,10 @@ describe("PositionsDiscoverer", function()
 		local actual = plugin.discover_positions(file_path)
 
 		-- then
-		local test_name = actual:to_list()[2][2][2][1].name
+		local test_name = actual:to_list()[2][2][2][2][1].name
 		assert.equals(test_name, "someTest")
+
+		local another_outer_test_name = actual:to_list()[2][2][3][1].name
+		assert.equals(another_outer_test_name, "oneMoreOuterTest")
 	end)
 end)

--- a/tests/core/result_builder_spec.lua
+++ b/tests/core/result_builder_spec.lua
@@ -40,12 +40,12 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
       {
-        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ExampleTest.java::shouldFail"] = {
-          errors = {{ line=13, message="expected:<true>butwas:<false>" }},
+        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ExampleTest.java::ExampleTest::shouldFail"] = {
+          errors = {{ line=13, message="expected: <true> but was: <false>" }},
           short = "expected: <true> but was: <false>",
           status = "failed"
         },
-        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ExampleTest.java::shouldNotFail"] = {
+        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ExampleTest.java::ExampleTest::shouldNotFail"] = {
           status = "passed"
         }
       }
@@ -81,7 +81,7 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
       {
-        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ErroneousTest.java::shouldFailOnError"] = {
+        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ErroneousTest.java::ErroneousTest::shouldFailOnError"] = {
 	        errors = {{ message="Error creating bean with name 'com.example.ErroneousTest': Injection of autowired dependencies failed" }},
           short = "Error creating bean with name 'com.example.ErroneousTest': Injection of autowired dependencies failed",
           status = "failed"
@@ -119,12 +119,12 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
       {
-        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ExampleTest.java::shouldFail"] = {
+        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ExampleTest.java::ExampleTest::shouldFail"] = {
 	        errors = {{ line=14,message="org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>" }},
           short = "org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>",
           status = "failed"
         },
-        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ExampleTest.java::shouldNotFail"] = {
+        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ExampleTest.java::ExampleTest::shouldNotFail"] = {
           status = "passed"
         }
       }
@@ -161,7 +161,7 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
     {
-      ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/SingleMethodFailingTest.java::shouldFail"] 
+      ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/SingleMethodFailingTest.java::SingleMethodFailingTest::shouldFail"] 
       = { 
 	      errors = {{ line=9,message="org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>" }},
         short = "org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>",
@@ -200,7 +200,7 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
     {
-      ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/SingleMethodFailingTest.java::shouldFail"] 
+      ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/SingleMethodFailingTest.java::SingleMethodFailingTest::shouldFail"] 
       = { 
         errors = {{ line=9, message="expected: <true> but was: <false>" }},
         short = "expected: <true> but was: <false>",
@@ -239,7 +239,7 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
       {
-        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/demo/RepositoryIT.java::shouldWorkProperly"]
+        ["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/demo/RepositoryIT.java::RepositoryIT::shouldWorkProperly"]
 
       = {status="passed"}
       }
@@ -276,7 +276,7 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
 	      {
-		["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ParameterizedMethodTest.java::parameterizedMethodShouldFail"]
+		["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ParameterizedMethodTest.java::ParameterizedMethodTest::parameterizedMethodShouldFail"]
 		  = {
         errors={{message="
 			  parameterizedMethodShouldFail(Integer, Integer)[1] -> org.opentest4j.AssertionFailedError: expected: <true> but was: <false>\n
@@ -289,7 +289,7 @@ describe("ResultBuilder", function()
 		    status="failed"
 		  }
 	      ,
-		["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ParameterizedMethodTest.java::parameterizedMethodShouldNotFail"]
+		["{{current_dir}}tests/fixtures/maven-demo/src/test/java/com/example/ParameterizedMethodTest.java::ParameterizedMethodTest::parameterizedMethodShouldNotFail"]
 		  = {status="passed"}
 	      }
 	    ]]
@@ -331,24 +331,24 @@ describe("ResultBuilder", function()
 		local actual = table_to_string(results)
 		local expected = [[
       {
-        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::shouldFail"]
+        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::ParameterizedTests::shouldFail"]
           = {
         errors= {{message="shouldFail(int,int,int)[1]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>\nshouldFail(int,int,int)[2]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>\nshouldFail(int,int,int)[3]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>"}},
           short="shouldFail(int,int,int)[1]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>\nshouldFail(int,int,int)[2]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>\nshouldFail(int,int,int)[3]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>",
           status="failed"
           }
         ,
-        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::shouldFail2"]
+        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::ParameterizedTests::shouldFail2"]
           = {
         errors= {{message="shouldFail2(int,int,int)[2]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>\nshouldFail2(int,int,int)[3]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>"}},
           short="shouldFail2(int,int,int)[2]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>\nshouldFail2(int,int,int)[3]->org.opentest4j.AssertionFailedError:expected:<true>butwas:<false>",
           status="failed"
           }
         ,
-        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::shouldPass"]
+        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::ParameterizedTests::shouldPass"]
           = {status="passed"}
         ,
-        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::shouldPass2"]
+        ["{{current_dir}}tests/fixtures/gradle-demo/src/test/java/com/example/ParameterizedTests.java::ParameterizedTests::shouldPass2"]
           = {status="passed"}
       }
     ]]
@@ -392,14 +392,14 @@ describe("ResultBuilder", function()
 
 			local expected = [[
       {
-        ["{{current_dir}}tests/fixtures/{{project_type}}-demo/src/test/java/com/example/EmptySourceTest.java::emptySourceShouldFail"]
+        ["{{current_dir}}tests/fixtures/{{project_type}}-demo/src/test/java/com/example/EmptySourceTest.java::EmptySourceTest::emptySourceShouldFail"]
           = {
           errors={{message="emptySourceShouldFail(String)[1] -> org.opentest4j.AssertionFailedError: expected: <false> but was: <true>"}},
           short="emptySourceShouldFail(String)[1] -> org.opentest4j.AssertionFailedError: expected: <false> but was: <true>",
           status="failed"
           }
         ,
-        ["{{current_dir}}tests/fixtures/{{project_type}}-demo/src/test/java/com/example/EmptySourceTest.java::emptySourceShouldPass"]
+        ["{{current_dir}}tests/fixtures/{{project_type}}-demo/src/test/java/com/example/EmptySourceTest.java::EmptySourceTest::emptySourceShouldPass"]
           = {status="passed"}
       }
     ]]

--- a/tests/fixtures/SomeNestedTest.java
+++ b/tests/fixtures/SomeNestedTest.java
@@ -1,9 +1,16 @@
 
 public class SomeTest {
     public static class SomeNestedTest {
+        public static class AnotherNestedTest {
+            @Test
+            public void someTest() {
+                assertEquals(1 + 1, 2);
+            }
+        }
+
         @Test
-        public void someTest() {
+        public void oneMoreOuterTest() {
             assertEquals(1 + 1, 2);
-        } 
+        }
     }
 }

--- a/tests/fixtures/SomeNestedTest.java
+++ b/tests/fixtures/SomeNestedTest.java
@@ -1,0 +1,9 @@
+
+public class SomeTest {
+    public static class SomeNestedTest {
+        @Test
+        public void someTest() {
+            assertEquals(1 + 1, 2);
+        } 
+    }
+}

--- a/tests/fixtures/gradle-demo/src/test/java/com/example/NestedTests.java
+++ b/tests/fixtures/gradle-demo/src/test/java/com/example/NestedTests.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class NestedTests {
+
+        public static class SomeNestedTest {
+
+                @Test
+                void shouldSucceed() {
+                        assertEquals(2, 1 + 1);
+                }
+
+                @Test
+                void shouldFail() {
+                        assertEquals(3, 1 + 1);
+                }
+
+        }
+
+}

--- a/tests/fixtures/maven-demo/src/test/java/com/example/NestedTests.java
+++ b/tests/fixtures/maven-demo/src/test/java/com/example/NestedTests.java
@@ -1,0 +1,23 @@
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class NestedTests {
+
+        public static class SomeNestedTest {
+
+                @Test
+                void shouldSucceed() {
+                        assertEquals(2, 1 + 1);
+                }
+
+                @Test
+                void shouldFail() {
+                        assertEquals(3, 1 + 1);
+                }
+
+        }
+
+}


### PR DESCRIPTION
~~Fixes #54~~

This will allow neotest to identify classes as namespaces and will make #54 easier to resolve. 