### PR TITLE
Add support for JUnit Pioneer's @CartesianTest

### DIFF
--- a/lua/neotest-java/core/positions_discoverer.lua
+++ b/lua/neotest-java/core/positions_discoverer.lua
@@ -19,7 +19,7 @@ function PositionsDiscoverer.discover_positions(file_path)
         (modifiers
           (marker_annotation
             name: (identifier) @annotation 
-              (#any-of? @annotation "Test" "ParameterizedTest")
+              (#any-of? @annotation "Test" "ParameterizedTest" "CartesianTest")
             )
         )
         name: (identifier) @test.name


### PR DESCRIPTION
JUnit Pioneer is an extension of JUnit 5 and has a `@CartesianTest` annotation that allows for multiple parameters (instead of a single parameter in the traditional `@ParameterizedTest`.)

This PR adds support for that new annotation.

Ref: https://junit-pioneer.org/docs/cartesian-product/