### PR TITLE
fix: parameterized test regex

### DIFF
--- a/lua/neotest-java/core/result_builder.lua
+++ b/lua/neotest-java/core/result_builder.lua
@@ -22,20 +22,13 @@ local function is_array(tbl)
 end
 
 local function is_parameterized_test(testcases, name)
-	local count = 0
 	-- regex to match the name with some parameters and index at the end
 	-- example: subtractAMinusBEqualsC(int, int, int)[1]
-	local regex = name .. "%(([^%)]+)%)%[([%d]+)%]"
+	-- local regex = name .. "%(([^%)]+)%)%[([%d]+)%]"
+	local regex = name .. "[%(%{].*%[%d+%]$"
 
-	-- TODO: indeed if the regex match just one time,
-	-- it is a parameterized test of one test case
-	-- so this for loop is not necessary
 	for k, _ in pairs(testcases) do
 		if string.match(k, regex) then
-			count = count + 1
-		end
-
-		if count >= 1 then
 			return true
 		end
 	end
@@ -46,7 +39,7 @@ end
 local function extract_test_failures(testcases, name)
 	-- regex to match the name with some parameters and index at the end
 	-- example: subtractAMinusBEqualsC(int, int, int)[1]
-	local regex = name .. "%(([^%)]+)%)%[([%d]+)%]"
+	local regex = name .. "[%(%{].*%[%d+%]$"
 
 	local failures = {}
 	for k, v in pairs(testcases) do

--- a/tests/core/result_builder_spec.lua
+++ b/tests/core/result_builder_spec.lua
@@ -279,7 +279,7 @@ describe("ResultBuilder", function()
 			  parameterizedMethodShouldFail(Integer, Integer)[1] -> org.opentest4j.AssertionFailedError: expected: <true> but was: <false>\n
 			  parameterizedMethodShouldFail(Integer, Integer)[2] -> org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
         "}},
-		    short="
+	    short="
 			  parameterizedMethodShouldFail(Integer, Integer)[1] -> org.opentest4j.AssertionFailedError: expected: <true> but was: <false>\n
 			  parameterizedMethodShouldFail(Integer, Integer)[2] -> org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
 		    ",


### PR DESCRIPTION
What all names given by JUnit reports to parameterized tests have in common is that they have:
* the name of the function
* some characthers in the middle starting with `[` or `{`
* ends with the index of the testcase inside square brackets.