### PR TITLE
fix: avoid race conditions on global variables

### DIFF
--- a/lua/neotest-java/core/dir_filter.lua
+++ b/lua/neotest-java/core/dir_filter.lua
@@ -1,4 +1,4 @@
-DirFilter = {
+local DirFilter = {
 	-- List of directories to exclude from search
 	excluded_directories = {
 		"target",

--- a/lua/neotest-java/core/file_checker.lua
+++ b/lua/neotest-java/core/file_checker.lua
@@ -1,5 +1,5 @@
 local File = require("neotest.lib.file")
-FileChecker = {
+local FileChecker = {
 	test_file_patterns = {
 		"IT%.java$",
 		"Test%.java$",


### PR DESCRIPTION
1. there was no reason for those to be global variables
2. having it local avoids annoying race conditions