### PR TITLE
pass all java class filepaths to javac command

### DIFF
--- a/lua/neotest-java/build_tool/gradle.lua
+++ b/lua/neotest-java/build_tool/gradle.lua
@@ -70,7 +70,7 @@ gradle.get_output_dir = function()
 	return "build/neotest-java"
 end
 
-gradle.get_sources_glob = function()
+gradle.get_sources = function()
 	local sources = scan.scan_dir(gradle.source_dir(), {
 		search_pattern = JAVA_FILE_PATTERN,
 	})
@@ -85,7 +85,7 @@ gradle.get_sources_glob = function()
 	return table.concat({ sources_str, generated_sources_str }, " ")
 end
 
-gradle.get_test_sources_glob = function()
+gradle.get_test_sources = function()
 	local test_sources = scan.scan_dir("src/test/java", {
 		search_pattern = JAVA_FILE_PATTERN,
 	})

--- a/lua/neotest-java/build_tool/gradle.lua
+++ b/lua/neotest-java/build_tool/gradle.lua
@@ -6,6 +6,8 @@ local File = require("neotest.lib.file")
 local run = require("neotest-java.command.run")
 local binaries = require("neotest-java.command.binaries")
 
+local JAVA_FILE_PATTERN = ".+%.java"
+
 local function find_file_in_dir(filename, dir)
 	return totable(
 		--
@@ -69,18 +71,25 @@ gradle.get_output_dir = function()
 end
 
 gradle.get_sources_glob = function()
-	-- check if there are generated sources
-	local generated_sources = scan.scan_dir("build", {
-		search_pattern = ".+%.java",
+	local sources = scan.scan_dir(gradle.source_dir(), {
+		search_pattern = JAVA_FILE_PATTERN,
 	})
-	if #generated_sources > 0 then
-		return "src/main/**/*.java build/**/*.java"
-	end
-	return "src/main/**/*.java"
+
+	local generated_sources = scan.scan_dir("build", {
+		search_pattern = JAVA_FILE_PATTERN,
+	})
+
+	local sources_str = table.concat(sources, " ")
+	local generated_sources_str = table.concat(generated_sources, " ")
+
+	return table.concat({ sources_str, generated_sources_str }, " ")
 end
 
 gradle.get_test_sources_glob = function()
-	return "src/test/**/*.java"
+	local test_sources = scan.scan_dir("src/test/java", {
+		search_pattern = JAVA_FILE_PATTERN,
+	})
+	return table.concat(test_sources, " ")
 end
 
 gradle.get_resources = function()

--- a/lua/neotest-java/build_tool/init.lua
+++ b/lua/neotest-java/build_tool/init.lua
@@ -5,9 +5,9 @@ local gradle = require("neotest-java.build_tool.gradle")
 ---@field get_dependencies_classpath fun(): string
 ---@field get_output_dir fun(): string
 ---@field write_classpath fun(classpath_filepath: string) writes the classpath into a file
----@field get_sources_glob fun(): string
+---@field get_sources fun(): string
 ---@field source_dir fun(): string
----@field get_test_sources_glob fun(): string
+---@field get_test_sources fun(): string
 ---@field get_resources fun(): string[]
 local BuildTool = {}
 

--- a/lua/neotest-java/build_tool/maven.lua
+++ b/lua/neotest-java/build_tool/maven.lua
@@ -34,7 +34,7 @@ maven.get_output_dir = function()
 	return "target/neotest-java"
 end
 
-maven.get_sources_glob = function()
+maven.get_sources = function()
 	local sources = scan.scan_dir(maven.source_directory(), {
 		search_pattern = JAVA_FILE_PATTERN,
 	})
@@ -50,7 +50,7 @@ maven.get_sources_glob = function()
 	return table.concat({ sources_str, generated_sources_str }, " ")
 end
 
-maven.get_test_sources_glob = function()
+maven.get_test_sources = function()
 	-- TODO: read from pom.xml <testSourceDirectory>
 
 	local test_sources = scan.scan_dir(maven.test_source_directory(), {

--- a/lua/neotest-java/build_tool/maven.lua
+++ b/lua/neotest-java/build_tool/maven.lua
@@ -4,6 +4,8 @@ local scan = require("plenary.scandir")
 local mvn = require("neotest-java.command.binaries").mvn
 local logger = require("neotest.logging")
 
+local JAVA_FILE_PATTERN = ".+%.java"
+
 ---@type neotest-java.BuildTool
 local maven = {}
 
@@ -33,26 +35,29 @@ maven.get_output_dir = function()
 end
 
 maven.get_sources_glob = function()
-	-- TODO: read from pom.xml <sourceDirectory>
-
-	-- check if there are generated sources
-	local generated_sources = scan.scan_dir("target", {
-		search_pattern = ".+%.java",
+	local sources = scan.scan_dir(maven.source_directory(), {
+		search_pattern = JAVA_FILE_PATTERN,
 	})
-	if #generated_sources > 0 then
-		return ("%s/**/*.java target/**/*.java"):format(maven.source_directory())
-	end
-	return ("%s/**/*.java"):format(maven.source_directory())
+
+	local generated_sources = scan.scan_dir("target", {
+		search_pattern = JAVA_FILE_PATTERN,
+	})
+
+	-- combine sources and generated sources
+	local sources_str = table.concat(sources, " ")
+	local generated_sources_str = table.concat(generated_sources, " ")
+
+	return table.concat({ sources_str, generated_sources_str }, " ")
 end
 
 maven.get_test_sources_glob = function()
 	-- TODO: read from pom.xml <testSourceDirectory>
 
-	if tag then
-		return tag
-	end
+	local test_sources = scan.scan_dir(maven.test_source_directory(), {
+		search_pattern = JAVA_FILE_PATTERN,
+	})
 
-	return "src/test/**/*.java"
+	return table.concat(test_sources, " ")
 end
 
 maven.get_resources = function()

--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -6,7 +6,7 @@ local java = binaries.java
 
 local function wrap_command_as_bash(command)
 	return ([=[
-  bash -O globstar -c '
+  bash -c '
     %s
   '
   ]=]):format(command)

--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -114,8 +114,8 @@ local CommandBuilder = {
 		local classpath_filename = build_dir .. "/classpath.txt"
 		local reference = self._test_references[1]
 		local resources = table.concat(build_tool.get_resources(), ":")
-		local source_classes_glob = build_tool.get_sources_glob()
-		local test_classes_glob = build_tool.get_test_sources_glob()
+		local source_classes = build_tool.get_sources()
+		local test_classes = build_tool.get_test_sources()
 
 		local ref
 		if reference.type == "test" then
@@ -130,10 +130,10 @@ local CommandBuilder = {
 		build_tool.write_classpath(classpath_filename)
 
 		local source_compilation_command = [[
-      {{javac}} -Xlint:none -d {{output_dir}} -cp $(cat {{classpath_filename}}) {{source_classes_glob}}
+      {{javac}} -Xlint:none -d {{output_dir}} -cp $(cat {{classpath_filename}}) {{source_classes}}
     ]]
 		local test_compilation_command = [[
-      {{javac}} -Xlint:none -d {{output_dir}} -cp $(cat {{classpath_filename}}):{{output_dir}} {{test_classes_glob}}
+      {{javac}} -Xlint:none -d {{output_dir}} -cp $(cat {{classpath_filename}}):{{output_dir}} {{test_classes}}
     ]]
 
 		local test_execution_command = [[
@@ -158,8 +158,8 @@ local CommandBuilder = {
 			["{{classpath_filename}}"] = classpath_filename,
 			["{{reports_dir}}"] = self._reports_dir,
 			["{{selectors}}"] = ref,
-			["{{source_classes_glob}}"] = source_classes_glob,
-			["{{test_classes_glob}}"] = test_classes_glob,
+			["{{source_classes}}"] = source_classes,
+			["{{test_classes}}"] = test_classes,
 		}
 		iter(placeholders):each(function(k, v)
 			command = command:gsub(k, v)


### PR DESCRIPTION
Related: #98 

Added all filepaths of the java classes for the `javac` command to avoid using globs as it is not compatible in all systems.