### PR TITLE
fix: explicit address for compatibility

### DIFF
--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -198,7 +198,8 @@ local CommandBuilder = {
 		local junit_command = {
 			command = java(),
 			args = {
-				"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:" .. port,
+				"-Xdebug",
+				"-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0.0.0.0:" .. port,
 				"-jar",
 				self._junit_jar,
 				"execute",


### PR DESCRIPTION
Set the IP address for compatibility with older version not supporting `*:`.

Also adding `-Xdebug` arg as [java documentation](https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html) says: 
> Does nothing. Provided for backward compatibility.

For reference: 
* https://github.com/OpenLiberty/open-liberty/issues/7833
* https://github.com/sedici/docker-dspace/commit/63dbdac4c99575e4854e756687b1234948e6f9dc