### PR TITLE
Bugfix: Test execution stuck if a maven project do not have the neotest-java directory (first execution or after the mvn clean)

### DIFF
--- a/lua/neotest-java/build_tool/maven.lua
+++ b/lua/neotest-java/build_tool/maven.lua
@@ -72,6 +72,7 @@ maven.get_dependencies_classpath = function()
 	end
 
 	local command = mvn() .. " -q dependency:build-classpath -Dmdep.outputFile=target/neotest-java/classpath.txt"
+	run(command)
 	local dependency_classpath = run("cat target/neotest-java/classpath.txt")
 
 	if string.match(dependency_classpath, "ERROR") then


### PR DESCRIPTION
I've faced an issue that leads a test execution to the error because classpath.txt do not exist in target directory.
I've found that the row which I'm proposing to return back have been removed at commit 48efda01d1b9daff8c15322631f26b533d005336 . I presume it was done by mistake