### PR TITLE
fix: ignore wrappers

### DIFF
--- a/lua/neotest-java/command/binaries.lua
+++ b/lua/neotest-java/command/binaries.lua
@@ -1,4 +1,5 @@
 local File = require("neotest.lib.file")
+local ch = require("neotest-java.context_holder")
 
 local binaries = {
 
@@ -11,14 +12,14 @@ local binaries = {
 	end,
 
 	mvn = function()
-		if File.exists("mvnw") then
+		if File.exists("mvnw") and not ch.get_context().config.ignore_wrapper then
 			return "./mvnw"
 		end
 		return "mvn"
 	end,
 
 	gradle = function()
-		if File.exists("gradlew") then
+		if File.exists("gradlew") and not ch.get_context().config.ignore_wrapper then
 			return "./gradlew"
 		end
 		return "gradle"

--- a/lua/neotest-java/context_holder.lua
+++ b/lua/neotest-java/context_holder.lua
@@ -17,7 +17,7 @@ return {
 		return context
 	end,
 	set_opts = function(opts)
-		vim.tbl_extend("force", context.config, opts)
+		context.config = vim.tbl_extend("force", context.config, opts)
 		log.debug("Config updated: ", context.config)
 	end,
 	set_root = function(root)


### PR DESCRIPTION
Hello,
In NixOS it is impossible to use the wrappers from mvn and gradle and we have to always use the binaries which are installed via the derivations.

It looks like the `ignore_wrappers` option was ignored completely, and there was also a small bug when setting the options (it seems to me the API for `vim.tbl_extend` has changed, and it now returns a table instead of modifying the table in-place). I fixed both issues in this MR. 
Please tell me if there's something more I can do :)