### PR TITLE
Correctly detect the project runtime based on the active language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,20 @@ require("neotest").setup({
   adapters = {
     require("neotest-java")({
         ignore_wrapper = false, -- whether to ignore maven/gradle wrapper
+        java_runtimes = {
+            -- there are no runtimes defined by default, if you wish to have neotest-java resolve them based on your environment define them here, one could also define environment variables with the same key/names i.e. `JAVA_HOME_8` or `JAVA_HOME_11` or `JAVA_HOME_17` etc.
+            ["JAVA_HOME_8"] = "/absolute/path/to/jdk8/home/directory",
+            ["JAVA_HOME_11"] = "/absolute/path/to/jdk11/home/directory",
+            ["JAVA_HOME_17"] = "/absolute/path/to/jdk17/home/directory",
+        },
         junit_jar = nil,
         -- default: .local/share/nvim/neotest-java/junit-platform-console-standalone-[version].jar
     })
   }
 })
 ```
+
+Neotest java would try it's best to determine the current project's runtime based on the currently running lsp servers. Note that, neotest-java supports both native neovim lsp and coc.nvim, it would try to fallback to your project configuration, supports both maven (reading from pom.xml) & gradle (reading from build.gradle or gradle.properties). In case the runtime is found but the location of it is not defined, neotest-java would prompt the user to input the absolute directory for the specific runtime version (only once).
 
 ## :octocat: Contributing
 Feel free to contribute to this project by creating issues for bug reports, feature requests, or suggestions.

--- a/lua/neotest-java/build_tool/gradle.lua
+++ b/lua/neotest-java/build_tool/gradle.lua
@@ -4,8 +4,7 @@ local totable = fun.totable
 local scan = require("plenary.scandir")
 
 local run = require("neotest-java.command.run")
-local runtime = require("neotest-java.command.runtime")
-local grdl = require("neotest-java.command.binaries").gradle
+local _gradle = require("neotest-java.command.binaries").gradle
 
 local JAVA_FILE_PATTERN = ".+%.java$"
 
@@ -103,12 +102,11 @@ gradle.get_dependencies_classpath = function()
 
 	-- '< /dev/null' is necessary
 	-- https://github.com/gradle/gradle/issues/15941#issuecomment-1191510921
-	-- fix: this has to go through system too, to set the env variables, or update nio.run
-	local command = { grdl(), "-q", "dependencies > build/neotest-java/dependencies.txt < /dev/null" }
-	local result = vim.system(command, { env = { ["JAVA_HOME"] = runtime() } }):wait()
+	-- fix: is is needed for something has to read the gradle.properties and / or build.gradle to parse the runtime here
+	local dependency_classpath = _gradle() .. "-q dependencies > build/neotest-java/dependencies.txt < /dev/null"
 
-	if not result or result.code ~= 0 then
-		error('error while running command "' .. table.concat(command, " "))
+	if string.match(dependency_classpath, "ERROR") then
+		error("error while running command " .. dependency_classpath)
 	end
 
 	local output = run("cat " .. gradle.get_output_dir() .. "/dependencies.txt")

--- a/lua/neotest-java/build_tool/gradle.lua
+++ b/lua/neotest-java/build_tool/gradle.lua
@@ -102,8 +102,9 @@ gradle.get_dependencies_classpath = function()
 
 	-- '< /dev/null' is necessary
 	-- https://github.com/gradle/gradle/issues/15941#issuecomment-1191510921
-	-- fix: is is needed for something has to read the gradle.properties and / or build.gradle to parse the runtime here
+	-- fix: do we need to provide explicit runtime to gradle ? thensomething has to read the gradle.properties and / or build.gradle to parse the runtime here
 	local dependency_classpath = _gradle() .. "-q dependencies > build/neotest-java/dependencies.txt < /dev/null"
+	run(dependency_classpath)
 
 	if string.match(dependency_classpath, "ERROR") then
 		error("error while running command " .. dependency_classpath)

--- a/lua/neotest-java/build_tool/maven.lua
+++ b/lua/neotest-java/build_tool/maven.lua
@@ -86,7 +86,7 @@ maven.get_dependencies_classpath = function()
 	local dependency_classpath = run("cat target/neotest-java/classpath.txt")
 
 	if string.match(dependency_classpath, "ERROR") then
-		error('error while running command "' .. command .. '" -> ' .. dependency_classpath)
+		error("error while running command " .. dependency_classpath)
 	end
 
 	memoized_result = dependency_classpath

--- a/lua/neotest-java/command/binaries.lua
+++ b/lua/neotest-java/command/binaries.lua
@@ -1,14 +1,16 @@
 local File = require("neotest.lib.file")
 local ch = require("neotest-java.context_holder")
+local runtime = require("neotest-java.command.runtime")
 
 local binaries = {
-
 	java = function()
-		return "java"
+		local runtime_path = runtime()
+		return runtime_path and vim.fs.normalize(string.format("%s/bin/java", runtime_path)) or "java"
 	end,
 
 	javac = function()
-		return "javac"
+		local runtime_path = runtime()
+		return runtime_path and vim.fs.normalize(string.format("%s/bin/javac", runtime_path)) or "javac"
 	end,
 
 	mvn = function()

--- a/lua/neotest-java/command/run.lua
+++ b/lua/neotest-java/command/run.lua
@@ -10,12 +10,14 @@ end
 
 ---@param command string | string[]
 ---@param output_file? string
-local function run(command, output_file)
+---@param args? table
+local function run(command, output_file, args)
 	if type(command) == "string" then
 		command = string_to_table(command)
 	end
 
-	local exit_code, res = process.run(command, { stdout = true, stderr = true })
+	local exit_code, res =
+		process.run(command, vim.tbl_deep_extend("force", { stdout = true, stderr = true }, args or {}))
 
 	assert(
 		exit_code == 0,

--- a/lua/neotest-java/command/runtime.lua
+++ b/lua/neotest-java/command/runtime.lua
@@ -1,18 +1,23 @@
+local File = require("neotest.lib.file")
+
+local read_xml_tag = require("neotest-java.util.read_xml_tag")
 local log = require("neotest-java.logger")
 local lsp = require("neotest-java.lsp")
 local nio = require("nio")
 
 local COMPILER = "org.eclipse.jdt.core.compiler.source"
 local LOCATION = "org.eclipse.jdt.ls.core.vm.location"
+local RUNTIMES = {}
 
 local function extract_runtime(bufnr)
 	local uri = vim.uri_from_bufnr(bufnr)
-	local error, settings, client = lsp.execute_command({
-		command = "java.project.getSettings",
-		arguments = { uri, { COMPILER, LOCATION } },
-	}, bufnr)
+	local error, settings, client = nil, nil, nil
+	--    lsp.execute_command({
+	-- 	command = "java.project.getSettings",
+	-- 	arguments = { uri, { COMPILER, LOCATION } },
+	-- }, bufnr)
 
-	if error ~= nil then
+	if error ~= nil or client == nil then
 		return
 	end
 
@@ -58,7 +63,47 @@ local function get_runtime(opts)
 	if runtime and #runtime > 0 then
 		return runtime
 	end
-	log.error("Unable to extract project runtime")
+
+	if File.exists("pom.xml") then
+		local plugins = read_xml_tag("pom.xml", "project.build.plugins.plugin")
+		for _, plugin in ipairs(plugins or {}) do
+			if plugin.artifactId == "maven-compiler-plugin" and plugin.configuration then
+				if plugin.configuration.target ~= plugin.configuration.source then
+					error("Target and source mismatch detected in maven-compiler-plugin")
+				end
+				local target_version = vim.split(plugin.configuration.target, "%.")
+				local actual_version = target_version[#target_version]
+				if RUNTIMES[actual_version] then
+					return RUNTIMES[actual_version]
+				end
+
+				local runtime_name = string.format("JAVA_HOME_%d", actual_version)
+				if vim.env and vim.env[runtime_name] then
+					return vim.env[runtime_name]
+				else
+					local message = string.format(
+						"Enter runtime directory for JDK-%s (defaults to JAVA_HOME if empty): ",
+						actual_version
+					)
+					local runtime_path = nio.fn.input({
+						default = "",
+						prompt = message,
+						completion = "dir",
+						cancelreturn = "__INPUT_CANCELLED__",
+					})
+					if not runtime_path or runtime_path == "__INPUT_CANCELLED__" then
+						return vim.env.JAVA_HOME
+					end
+					RUNTIMES[actual_version] = runtime_path
+					return runtime_path
+				end
+			end
+		end
+	elseif File.exists("build.gradle") then
+		-- fix: what to do here, is it needed, or does gradle pick it up from the local project config, have to check ?
+		return nil
+	end
+	log.error("Unable to extract a valid project runtime")
 	return nil
 end
 

--- a/lua/neotest-java/command/runtime.lua
+++ b/lua/neotest-java/command/runtime.lua
@@ -11,13 +11,13 @@ local RUNTIMES = {}
 
 local function extract_runtime(bufnr)
 	local uri = vim.uri_from_bufnr(bufnr)
-	local error, settings, client = nil, nil, nil
-	--    lsp.execute_command({
-	-- 	command = "java.project.getSettings",
-	-- 	arguments = { uri, { COMPILER, LOCATION } },
-	-- }, bufnr)
+	local err, settings, client = nil, nil, nil
+	lsp.execute_command({
+		command = "java.project.getSettings",
+		arguments = { uri, { COMPILER, LOCATION } },
+	}, bufnr)
 
-	if error ~= nil or client == nil then
+	if err ~= nil or client == nil then
 		return
 	end
 

--- a/lua/neotest-java/command/runtime.lua
+++ b/lua/neotest-java/command/runtime.lua
@@ -1,0 +1,65 @@
+local log = require("neotest-java.logger")
+local lsp = require("neotest-java.lsp")
+local nio = require("nio")
+
+local COMPILER = "org.eclipse.jdt.core.compiler.source"
+local LOCATION = "org.eclipse.jdt.ls.core.vm.location"
+
+local function extract_runtime(bufnr)
+	local uri = vim.uri_from_bufnr(bufnr)
+	local error, settings, client = lsp.execute_command({
+		command = "java.project.getSettings",
+		arguments = { uri, { COMPILER, LOCATION } },
+	}, bufnr)
+
+	if error ~= nil then
+		return
+	end
+
+	local config = client.config.settings.java or {}
+	config = config.configuration or {}
+
+	local runtimes = config.runtimes
+	local location = vim.env.JAVA_HOME
+	local compiler = settings[COMPILER]
+
+	-- we can early exit with location here
+	if settings[LOCATION] then
+		location = settings[LOCATION]
+	else
+		-- go over available runtimes and resolve it
+		for _, runtime in ipairs(runtimes or {}) do
+			-- default runtimes get priority
+			if runtime.default == true then
+				location = runtime.path
+				break
+			end
+			-- match runtime against compliance version
+			local match = runtime.name:match(".*-(.*)")
+			if match and match == compiler then
+				location = runtime.path
+				break
+			end
+		end
+	end
+
+	if location and nio.fn.isdirectory(location) == 0 then
+		log.error(string.format("Invalid java runtime path location %s", location))
+		return
+	end
+	return location
+end
+
+---@return string | nil
+local function get_runtime(opts)
+	-- todo: this is not robust, there is no way to know where this is triggered from and if the current buffer is actually a 'java' one needs to be changed !!!
+	local bufnr = nio.api.nvim_get_current_buf()
+	local runtime = extract_runtime(bufnr)
+	if runtime and #runtime > 0 then
+		return runtime
+	end
+	log.error("Unable to extract project runtime")
+	return nil
+end
+
+return get_runtime

--- a/lua/neotest-java/command/runtime.lua
+++ b/lua/neotest-java/command/runtime.lua
@@ -103,6 +103,7 @@ local function get_runtime(opts)
 		end
 	elseif File.exists("build.gradle") then
 		-- fix: what to do here, is it needed, or does gradle pick it up from the local project config, have to check ?
+		-- fix: do we need to provide explicit runtime to gradle ? thensomething has to read the gradle.properties and / or build.gradle to parse the runtime here
 		return nil
 	end
 	log.error("Unable to extract a valid project runtime")

--- a/lua/neotest-java/context_holder.lua
+++ b/lua/neotest-java/context_holder.lua
@@ -3,6 +3,7 @@ local nio = require("nio")
 
 ---@type neotest-java.ConfigOpts
 local default_config = {
+	java_runtimes = {},
 	ignore_wrapper = false,
 	junit_jar = vim.fn.stdpath("data") .. "/neotest-java/junit-platform-console-standalone-1.10.1.jar",
 }
@@ -27,6 +28,7 @@ return {
 
 ---@class neotest-java.ConfigOpts
 ---@field ignore_wrapper boolean
+---@field java_runtimes table<string, string>
 ---@field junit_jar string
 
 ---@class neotest-java.Context

--- a/lua/neotest-java/lsp/init.lua
+++ b/lua/neotest-java/lsp/init.lua
@@ -4,26 +4,52 @@ local nio = require("nio")
 -- table that holds the language server settings, this is mostly done for interfacing with coc.nvim, since native neovim lsp clients hold their settings in the clients table
 local SETTINGS = {}
 
-local function execute_command(command, bufnr)
-	if vim.g.did_coc_loaded ~= nil then
-		-- cache the settings in case we use coc, since there is no way to obtain the client's settings
-		-- directly from the coc.nvim api, unlike with native lsp
-		SETTINGS = nio.fn["coc#util#get_config"]("java")
-	else
-		-- native lsp settings are contained in the client table, we are going to use those when executing
-		-- the native client request sync call.
-		SETTINGS = {}
+local function coc_command(command, _)
+	SETTINGS = nio.fn["coc#util#get_config"]("java")
+	if not command.arguments then
+		command.arguments = {}
 	end
+	if type(command.arguments) ~= "table" then
+		command.arguments = { command.arguments }
+	end
+	local ok, result = pcall(nio.fn.CocAction, "runCommand", command.command, unpack(command.arguments))
+	if not ok or not result then
+		log.warn(
+			string.format(
+				"Unable to run lsp %s command with payload %s",
+				command.command,
+				vim.inspect(command.arguments)
+			)
+		)
+	end
+	local err = not ok and result ~= vim.NIL and { message = result } or nil
+	return err,
+		result,
+		{
+			-- adapter for the native lsp client talbe format, to simplify external clients using this interface to talk to the lsp client, which ever it happens to be
+			name = "jdtls",
+			config = {
+				settings = {
+					java = SETTINGS,
+				},
+			},
+		}
+end
 
-	if vim.g.did_coc_loaded ~= nil then
-		if not command.arguments then
-			command.arguments = {}
+local function lsp_command(command, bufnr)
+	local clients = {}
+	for _, c in pairs(vim.lsp.get_clients({ bufnr = bufnr }) or {}) do
+		local command_provider = c.server_capabilities.executeCommandProvider
+		local commands = type(command_provider) == "table" and command_provider.commands or {}
+		if vim.tbl_contains(commands, command.command) then
+			table.insert(clients, c)
 		end
-		if type(command.arguments) ~= "table" then
-			command.arguments = { command.arguments }
-		end
-		local ok, result = pcall(nio.fn.CocAction, "runCommand", command.command, unpack(command.arguments))
-		if not ok or not result then
+	end
+	if vim.tbl_count(clients) == 0 then
+		log.warn(string.format("Unable to find lsp client that supports %s", command.command))
+	else
+		local response, error = clients[1].request_sync("workspace/executeCommand", command)
+		if error then
 			log.warn(
 				string.format(
 					"Unable to run lsp %s command with payload %s",
@@ -32,42 +58,15 @@ local function execute_command(command, bufnr)
 				)
 			)
 		end
-		local err = not ok and result ~= vim.NIL and { message = result } or nil
-		return err,
-			result,
-			{
-				-- adapter for the native lsp client talbe format, to simplify external clients using this interface to talk to the lsp client, which ever it happens to be
-				name = "jdtls",
-				config = {
-					settings = {
-						java = SETTINGS,
-					},
-				},
-			}
+		return error, response.result, clients[1]
+	end
+end
+
+local function execute_command(command, bufnr)
+	if vim.g.did_coc_loaded ~= nil then
+		coc_command(command, bufnr)
 	else
-		local clients = {}
-		for _, c in pairs(vim.lsp.get_clients({ bufnr = bufnr }) or {}) do
-			local command_provider = c.server_capabilities.executeCommandProvider
-			local commands = type(command_provider) == "table" and command_provider.commands or {}
-			if vim.tbl_contains(commands, command.command) then
-				table.insert(clients, c)
-			end
-		end
-		if vim.tbl_count(clients) == 0 then
-			log.warn(string.format("Unable to find lsp client that supports %s", command.command))
-		else
-			local response, error = clients[1].request_sync("workspace/executeCommand", command)
-			if error then
-				log.warn(
-					string.format(
-						"Unable to run lsp %s command with payload %s",
-						command.command,
-						vim.inspect(command.arguments)
-					)
-				)
-			end
-			return error, response.result, clients[1]
-		end
+		lsp_command(command, bufnr)
 	end
 end
 

--- a/lua/neotest-java/lsp/init.lua
+++ b/lua/neotest-java/lsp/init.lua
@@ -64,9 +64,9 @@ end
 
 local function execute_command(command, bufnr)
 	if vim.g.did_coc_loaded ~= nil then
-		coc_command(command, bufnr)
+		return coc_command(command, bufnr)
 	else
-		lsp_command(command, bufnr)
+		return lsp_command(command, bufnr)
 	end
 end
 

--- a/lua/neotest-java/lsp/init.lua
+++ b/lua/neotest-java/lsp/init.lua
@@ -32,8 +32,8 @@ local function execute_command(command, bufnr)
 				)
 			)
 		end
-		local error = not ok and result ~= vim.NIL and { message = result } or nil
-		return error,
+		local err = not ok and result ~= vim.NIL and { message = result } or nil
+		return err,
 			result,
 			{
 				-- adapter for the native lsp client talbe format, to simplify external clients using this interface to talk to the lsp client, which ever it happens to be
@@ -62,7 +62,7 @@ local function execute_command(command, bufnr)
 					string.format(
 						"Unable to run lsp %s command with payload %s",
 						command.command,
-						vim.sinepct(command.arguments)
+						vim.inspect(command.arguments)
 					)
 				)
 			end

--- a/lua/neotest-java/lsp/init.lua
+++ b/lua/neotest-java/lsp/init.lua
@@ -1,0 +1,76 @@
+local log = require("neotest-java.logger")
+local nio = require("nio")
+
+-- table that holds the language server settings, this is mostly done for interfacing with coc.nvim, since native neovim lsp clients hold their settings in the clients table
+local SETTINGS = {}
+
+local function execute_command(command, bufnr)
+	if vim.g.did_coc_loaded ~= nil then
+		-- cache the settings in case we use coc, since there is no way to obtain the client's settings
+		-- directly from the coc.nvim api, unlike with native lsp
+		SETTINGS = nio.fn["coc#util#get_config"]("java")
+	else
+		-- native lsp settings are contained in the client table, we are going to use those when executing
+		-- the native client request sync call.
+		SETTINGS = {}
+	end
+
+	if vim.g.did_coc_loaded ~= nil then
+		if not command.arguments then
+			command.arguments = {}
+		end
+		if type(command.arguments) ~= "table" then
+			command.arguments = { command.arguments }
+		end
+		local ok, result = pcall(nio.fn.CocAction, "runCommand", command.command, unpack(command.arguments))
+		if not ok or not result then
+			log.warn(
+				string.format(
+					"Unable to run lsp %s command with payload %s",
+					command.command,
+					vim.inspect(command.arguments)
+				)
+			)
+		end
+		local error = not ok and result ~= vim.NIL and { message = result } or nil
+		return error,
+			result,
+			{
+				-- adapter for the native lsp client talbe format, to simplify external clients using this interface to talk to the lsp client, which ever it happens to be
+				name = "jdtls",
+				config = {
+					settings = {
+						java = SETTINGS,
+					},
+				},
+			}
+	else
+		local clients = {}
+		for _, c in pairs(vim.lsp.get_clients({ bufnr = bufnr }) or {}) do
+			local command_provider = c.server_capabilities.executeCommandProvider
+			local commands = type(command_provider) == "table" and command_provider.commands or {}
+			if vim.tbl_contains(commands, command.command) then
+				table.insert(clients, c)
+			end
+		end
+		if vim.tbl_count(clients) == 0 then
+			log.warn(string.format("Unable to find lsp client that supports %s", command.command))
+		else
+			local response, error = clients[1].request_sync("workspace/executeCommand", command)
+			if error then
+				log.warn(
+					string.format(
+						"Unable to run lsp %s command with payload %s",
+						command.command,
+						vim.sinepct(command.arguments)
+					)
+				)
+			end
+			return error, response.result, clients[1]
+		end
+	end
+end
+
+return {
+	execute_command = execute_command,
+}

--- a/lua/neotest-java/util/read_xml_tag.lua
+++ b/lua/neotest-java/util/read_xml_tag.lua
@@ -1,7 +1,6 @@
 local memo = require("neotest.lib.func_util.memoize")
 local file = require("neotest.lib.file")
 local xml = require("neotest.lib.xml")
-local logger = require("neotest.logging")
 
 ---@param filepath string
 ---@param selector string ex: project.build.sourceDirectory
@@ -16,12 +15,15 @@ local read_xml_tag = memo(function(filepath, selector)
 			return nil
 		end
 		parsed = parsed[tag]
+		vim.print(tag, parsed)
 	end
 
-	if type(parsed) == "table" then
-		return nil
-	end
-
+	-- why ? there are tags which can hold multiple tags / array of tags ?
+	-- such as dependencies or plugins
+	-- if type(parsed) == "table" then
+	-- 	return nil
+	-- end
+	--
 	return parsed
 end, cache)
 

--- a/lua/neotest-java/util/read_xml_tag.lua
+++ b/lua/neotest-java/util/read_xml_tag.lua
@@ -15,7 +15,6 @@ local read_xml_tag = memo(function(filepath, selector)
 			return nil
 		end
 		parsed = parsed[tag]
-		vim.print(tag, parsed)
 	end
 
 	-- why ? there are tags which can hold multiple tags / array of tags ?
@@ -23,7 +22,7 @@ local read_xml_tag = memo(function(filepath, selector)
 	-- if type(parsed) == "table" then
 	-- 	return nil
 	-- end
-	--
+
 	return parsed
 end, cache)
 


### PR DESCRIPTION
The goal of this pr is to correctly resolve the runtime home directory of the jdk that a specific project is using, after that the JAVA_HOME env variable is set to that, and the appropriate maven or gradle commands can be run. 

This has to be done when we call maven or gradle. The reason this is needed is pretty simple, noone has just one single runtime installed on their system, and most people work with multiple java projects configured/developed to work with different runtime versions. 

For example say a user has installed the latest jdk & setup his JAVA_HOME and PATH to point to jdk21, however the user would like to run/compile the tests for an older java 8, 11 or 17 spring project. 

The JAVA_HOME variable has to be set to the `correct runtime for the project before` any relevant maven or gradle commands are run otherwise, for more simple projects you might get by and compile it, but for more complex projects which might be using deprecated or straight up removed features between major jdk versions, you will either fail to compile the code or you will encounter a runtime exception while running the code.

By default maven always picks up JAVA_HOME, you can also configure this in the pom itself, (by adding additional toolchain and compiler plugins) by setting the path to the runtime in the compiler plugin (for your local machine) gradle is more versatile it still reads JAVA_HOME, however you can start it with `-D` argument or you can configure the path to the runtime in build.gradle. 

Both maven and gradle have toolchain plugins which allow them to specify the java version/runtime for the project separate from the java stack on user's PATH, `manually, proivde absolute path to the desired runtime on your local machine, that the project has to be run with`,  however in practice noone does this, locally, since most projects are microservices, they rely on pod's env.

You can see why this is kind of needed, while it is possible to provide the path to the runtime for a project, and have it be separate from JAVA_HOME (i.e the java stack which is on your PATH)
- would not be deployeable/portable in a cluster
- it is not usually done, since it requires user input, locally modifying the pom
- it is specific for the user's machine, people install them in different places

The solution in this plugin is to provide the runtimes just once, either as env variables JAVA_HOME_XX, or in your lua config, not having to modify the pom for each project, locally, separately, having to add additional maven/gradle plugins to the project just to be able to specify this etc, and you would certainly forget to do that.

TL;DR - Nothing guarantees you that the java stack on user's PATH is the one a specific project requires to be compiled / depends on. 