### PR TITLE
Add -parameters flag

### DIFF
--- a/lua/neotest-java/build_tool/init.lua
+++ b/lua/neotest-java/build_tool/init.lua
@@ -38,6 +38,7 @@ build_tools.compile_sources = function(project_type)
 	local source_compilation_command_exited = nio.control.event()
 	local source_compilation_args = {
 		"-Xlint:none",
+		"-parameters",
 		"-d",
 		output_dir .. "/classes",
 		"@" .. output_dir .. "/cp_arguments.txt",
@@ -78,6 +79,7 @@ build_tools.compile_test_sources = function(project_type)
 	local test_compilation_command_exited = nio.control.event()
 	local test_sources_compilation_args = {
 		"-Xlint:none",
+		"-parameters",
 		"-d",
 		output_dir .. "/classes",
 		("@%s/cp_arguments.txt"):format(output_dir),

--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -128,10 +128,10 @@ local CommandBuilder = {
 		build_tool.prepare_classpath()
 
 		local source_compilation_command = [[
-      {{javac}} -Xlint:none -d {{output_dir}} {{classpath_arg}} {{source_classes}}
+      {{javac}} -Xlint:none -parameters -d {{output_dir}} {{classpath_arg}} {{source_classes}}
     ]]
 		local test_compilation_command = [[
-      {{javac}} -Xlint:none -d {{output_dir}} {{classpath_arg}} {{test_classes}}
+      {{javac}} -Xlint:none -parameters -d {{output_dir}} {{classpath_arg}} {{test_classes}}
     ]]
 
 		local test_execution_command = [[


### PR DESCRIPTION
Hello,
most frameworks are using reflection mechanism to automatically detect a variable by its name (for example Spring's `@PathVariable`), and in order to make it work we have to compile the tests using the `-parameters` flag, otherwise the parameter's information will be skipped at compilation time and the tests will fail.

This simple PR adds the `-parameters` flag to the compilation phase.