### PR TITLE
Add support for processing junit4 reports from TEST-junit-vintage.xml

### DIFF
--- a/lua/neotest-java/core/spec_builder.lua
+++ b/lua/neotest-java/core/spec_builder.lua
@@ -90,7 +90,7 @@ function SpecBuilder.build_spec(args, project_type, config)
 		command = command:build(),
 		cwd = root,
 		symbol = position.name,
-		context = { reports_dir = reports_dir},
+		context = { reports_dir = reports_dir },
 	}
 end
 

--- a/lua/neotest-java/core/spec_builder.lua
+++ b/lua/neotest-java/core/spec_builder.lua
@@ -78,7 +78,7 @@ function SpecBuilder.build_spec(args, project_type, config)
 			symbol = position.name,
 			context = {
 				strategy = args.strategy,
-				report_file = reports_dir .. "/TEST-junit-jupiter.xml",
+				reports_dir = reports_dir,
 				terminated_command_event = terminated_command_event,
 			},
 		}
@@ -90,7 +90,7 @@ function SpecBuilder.build_spec(args, project_type, config)
 		command = command:build(),
 		cwd = root,
 		symbol = position.name,
-		context = { report_file = reports_dir .. "/TEST-junit-jupiter.xml" },
+		context = { reports_dir = reports_dir},
 	}
 end
 

--- a/lua/neotest-java/util/flat_map.lua
+++ b/lua/neotest-java/util/flat_map.lua
@@ -1,14 +1,14 @@
 local function flat_map(func, t)
-    local result = {}
-    for _, v in ipairs(t) do
-        local mapped = func(v)
-        if type(mapped) == "table" then
-            vim.list_extend(result, mapped)
-        else
-            table.insert(result, mapped)
-        end
-    end
-    return result
+	local result = {}
+	for _, v in ipairs(t) do
+		local mapped = func(v)
+		if type(mapped) == "table" then
+			vim.list_extend(result, mapped)
+		else
+			table.insert(result, mapped)
+		end
+	end
+	return result
 end
 
 return flat_map

--- a/lua/neotest-java/util/flat_map.lua
+++ b/lua/neotest-java/util/flat_map.lua
@@ -1,0 +1,14 @@
+local function flat_map(func, t)
+    local result = {}
+    for _, v in ipairs(t) do
+        local mapped = func(v)
+        if type(mapped) == "table" then
+            vim.list_extend(result, mapped)
+        else
+            table.insert(result, mapped)
+        end
+    end
+    return result
+end
+
+return flat_map

--- a/tests/core/result_builder_spec.lua
+++ b/tests/core/result_builder_spec.lua
@@ -4,6 +4,9 @@ local tempname_fn = require("nio").fn.tempname
 
 local current_dir = vim.fn.fnamemodify(vim.fn.expand("%:p:h"), ":p")
 local TEMPNAME = "/tmp/tempname-1234"
+local MAVEN_REPORTS_DIR = vim.loop.cwd() .. "/tests/fixtures/maven-demo/target/surefire-reports/"
+
+local GRADLE_REPORTS_DIR = vim.loop.cwd() .. "/tests/fixtures/gradle-groovy-demo/build/test-results/test"
 
 describe("ResultBuilder", function()
 	async.before_each(function()
@@ -22,8 +25,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = vim.loop.cwd() .. "/tests/fixtures/maven-demo",
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/maven-demo/target/surefire-reports/TEST-com.example.ExampleTest.xml",
+				reports_dir = MAVEN_REPORTS_DIR,
 			},
 		}
 
@@ -60,8 +62,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = current_dir .. "tests/fixtures/maven-demo",
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/maven-demo/target/surefire-reports/TEST-com.example.ErroneousTest.xml",
+				reports_dir = MAVEN_REPORTS_DIR,
 			},
 		}
 
@@ -98,8 +99,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = current_dir .. "tests/fixtures/gradle-groovy-demo",
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/gradle-groovy-demo/build/test-results/test/TEST-com.example.ExampleTest.xml",
+				reports_dir = GRADLE_REPORTS_DIR,
 			},
 		}
 
@@ -137,8 +137,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = current_dir .. "tests/fixtures/gradle-groovy-demo",
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/gradle-groovy-demo/build/test-results/test/TEST-com.example.SingleMethodFailingTest.xml",
+				reports_dir = GRADLE_REPORTS_DIR,
 			},
 		}
 
@@ -174,8 +173,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = current_dir .. "tests/fixtures/maven-demo",
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/gradle-groovy-demo/build/test-results/test/TEST-com.example.SingleMethodFailingTest.xml",
+				reports_dir = MAVEN_REPORTS_DIR,
 			},
 		}
 
@@ -195,9 +193,9 @@ describe("ResultBuilder", function()
 		local expected = {
 			[current_dir .. "tests/fixtures/maven-demo/src/test/java/com/example/SingleMethodFailingTest.java::SingleMethodFailingTest::shouldFail"] = {
 				errors = {
-					{ line = 9, message = "org.opentest4j.AssertionFailedError: expected: <true> but was: <false>" },
+					{ line = 9, message = "expected: <true> but was: <false>" },
 				},
-				short = "org.opentest4j.AssertionFailedError: expected: <true> but was: <false>",
+				short = "expected: <true> but was: <false>",
 				status = "failed",
 				output = TEMPNAME,
 			},
@@ -211,8 +209,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = current_dir .. "tests/fixtures/maven-demo",
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/maven-demo/target/surefire-reports/TEST-com.example.demo.RepositoryIT.xml",
+				reports_dir = MAVEN_REPORTS_DIR,
 			},
 		}
 
@@ -243,8 +240,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = current_dir .. "tests/fixtures/maven-demo",
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/maven-demo/target/surefire-reports/TEST-com.example.ParameterizedMethodTest.xml",
+				reports_dir = MAVEN_REPORTS_DIR,
 			},
 		}
 
@@ -300,8 +296,7 @@ describe("ResultBuilder", function()
 		local runSpec = {
 			cwd = current_dir .. "tests/fixtures/" .. project_dir,
 			context = {
-				report_file = vim.loop.cwd()
-					.. "/tests/fixtures/maven-demo/target/surefire-reports/TEST-com.example.EmptySourceTest.xml",
+				reports_dir = MAVEN_REPORTS_DIR,
 			},
 		}
 


### PR DESCRIPTION
Content: 
- spec_builder now just returns the reports_dir instead of a path to a file
- result_builder now builds results for all the possible report files
