### PR TITLE
fix: Add missing comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
   ```lua
   {
     "nvim-neotest/neotest",
-    ft = "java"
+    ft = "java",
     dependencies = {
       "rcasia/neotest-java",
     },


### PR DESCRIPTION
It looks like there is a missing comma in the README regarding the lazy.nvim installation.