### PR TITLE
fix: multiple classes at level zero

### DIFF
--- a/lua/neotest-java/types/test_class_patterns.lua
+++ b/lua/neotest-java/types/test_class_patterns.lua
@@ -1,0 +1,8 @@
+local TEST_CLASS_PATTERNS = {
+	"Test$",
+	"Tests$",
+	"Spec$",
+	"IT$",
+}
+
+return TEST_CLASS_PATTERNS

--- a/lua/neotest-java/util/resolve_qualified_name.lua
+++ b/lua/neotest-java/util/resolve_qualified_name.lua
@@ -1,16 +1,19 @@
 local read_file = require("neotest-java.util.read_file")
+local TEST_CLASS_PATTERNS = require("neotest-java.types.test_class_patterns")
 
 local function resolve_qualified_name(filename)
+	---@param raw_query string
+	---@param content string
+	---@return string[]
 	local function find_in_text(raw_query, content)
 		local query = vim.treesitter.query.parse("java", raw_query)
 
 		local lang_tree = vim.treesitter.get_string_parser(content, "java")
 		local root = lang_tree:parse()[1]:root()
 
-		local result = ""
+		local result = {}
 		for _, node, _ in query:iter_captures(root, content, 0, -1) do --luacheck: ignore 512 loop is executed at most once
-			result = vim.treesitter.get_node_text(node, content)
-			break
+			result[#result + 1] = vim.treesitter.get_node_text(node, content)
 		end
 		return result
 	end
@@ -36,8 +39,20 @@ local function resolve_qualified_name(filename)
     ((class_declaration (identifier) @target))
   ]]
 
-	local package_line = find_in_text(package_query, content)
-	local name = find_in_text(class_name_query, content)
+	local package_line = find_in_text(package_query, content)[1]
+	local names = find_in_text(class_name_query, content)
+
+	-- as there can be different class names
+	-- searches for the one the mathces the test class patterns
+	local name = ""
+	for _, _name in ipairs(names) do
+		for _, pattern in ipairs(TEST_CLASS_PATTERNS) do
+			if _name:find(pattern) then
+				name = _name
+				break
+			end
+		end
+	end
 
 	return package_line .. "." .. name
 end

--- a/tests/util/resolve_qualified_name_spec.lua
+++ b/tests/util/resolve_qualified_name_spec.lua
@@ -1,20 +1,48 @@
----@diagnostic disable: undefined-field
-local async = require("nio").tests
+local a = require("nio").tests
 local resolve_qualified_name = require("neotest-java.util.resolve_qualified_name")
 
-local cwd = vim.fn.getcwd()
-local EXAMPLE_FILEPATH = cwd .. "/tests/fixtures/maven-demo/src/test/java/com/example/ExampleTest.java"
-local EXAMPLE_PACKAGE = "com.example.ExampleTest"
-local BAD_EXAMPLE_FILEPATH = cwd .. "/tests/fixtures/maven-demo/src/test/java/com/example/NonExistentTest.java"
+describe("resolve_qualified_name", function()
+	local tmp_files
 
-describe("resolve_qualified_name function", function()
-	async.it("it should resolve package from filename", function()
-		assert.are.equal(EXAMPLE_PACKAGE, resolve_qualified_name(EXAMPLE_FILEPATH))
+	before_each(function()
+		tmp_files = {}
 	end)
 
-	async.it("it should error when file does not exist", function()
-		assert.has_error(function()
-			resolve_qualified_name(BAD_EXAMPLE_FILEPATH)
-		end, string.format("file does not exist: %s", BAD_EXAMPLE_FILEPATH))
+	after_each(function()
+		-- clear temporary files
+		for _, file in ipairs(tmp_files) do
+			os.remove(file)
+		end
 	end)
+
+	---@param content string
+	---@return string filename
+	local function create_tmp_file(content)
+		local tmp_file = os.tmpname()
+		table.insert(tmp_files, tmp_file)
+		local file = assert(io.open(tmp_file, "w"))
+		file:write(content)
+		file:close()
+		return tmp_file
+	end
+
+	local testcases = {
+		{
+			input = [[
+    package com.example;
+
+    public class ExampleTest {}
+
+    ]],
+			expected = "com.example.ExampleTest",
+		},
+	}
+
+	for _, case in ipairs(testcases) do
+		a.it("should resolve the qualified name of a file", function()
+			local result = resolve_qualified_name(create_tmp_file(case.input))
+
+			assert.are.same(case.expected, result)
+		end)
+	end
 end)

--- a/tests/util/resolve_qualified_name_spec.lua
+++ b/tests/util/resolve_qualified_name_spec.lua
@@ -55,4 +55,11 @@ describe("resolve_qualified_name", function()
 			assert.are.same(case.expected, result)
 		end)
 	end
+
+	a.it("it should error when file does not exist", function()
+		local bad_example_filepath = "some-fake-filename"
+		assert.has_error(function()
+			resolve_qualified_name(bad_example_filepath)
+		end, string.format("file does not exist: %s", bad_example_filepath))
+	end)
 end)

--- a/tests/util/resolve_qualified_name_spec.lua
+++ b/tests/util/resolve_qualified_name_spec.lua
@@ -31,7 +31,17 @@ describe("resolve_qualified_name", function()
 			input = [[
     package com.example;
 
-    public class ExampleTest {}
+    class ExampleTest {}
+
+    ]],
+			expected = "com.example.ExampleTest",
+		},
+		{
+			input = [[
+    package com.example;
+
+    class SomeConfig {}
+    class ExampleTest {}
 
     ]],
 			expected = "com.example.ExampleTest",


### PR DESCRIPTION
Fixes #161 

The problem was that there were several classes in the same test file at level zero and the first was being taken.

Example:

```java
// Filename: ApplicationTests.java

@TestConfiguration
class TestConfig {
    @Bean
    public String someBean() {
        return "some bean";
    }
}

@SpringBootTest
class ApplicationTests {

    @Test
    void contextLoads() {
    }

}
```

It was resolved by filtering non-test class names.