### PR TITLE
fix(resolve_qualified_name): null pointer when package is empty

### DIFF
--- a/lua/neotest-java/util/resolve_qualified_name.lua
+++ b/lua/neotest-java/util/resolve_qualified_name.lua
@@ -39,7 +39,9 @@ local function resolve_qualified_name(filename)
     ((class_declaration (identifier) @target))
   ]]
 
-	local package_line = find_in_text(package_query, content)[1]
+	local package_lines = find_in_text(package_query, content)
+
+	local package_line = (package_lines and package_lines[1]) and (package_lines[1] .. ".") or ""
 	local names = find_in_text(class_name_query, content)
 
 	-- as there can be different class names
@@ -54,7 +56,7 @@ local function resolve_qualified_name(filename)
 		end
 	end
 
-	return package_line .. "." .. name
+	return package_line .. name
 end
 
 return resolve_qualified_name

--- a/tests/util/resolve_qualified_name_spec.lua
+++ b/tests/util/resolve_qualified_name_spec.lua
@@ -46,6 +46,12 @@ describe("resolve_qualified_name", function()
     ]],
 			expected = "com.example.ExampleTest",
 		},
+		{
+			input = [[
+    class ExampleTest {}
+    ]],
+			expected = "ExampleTest",
+		},
 	}
 
 	for _, case in ipairs(testcases) do


### PR DESCRIPTION
Fix a null pointer when the test class has no package at all.

Example file:

```java
// file:  ExampleTest.java
class ExampleTest {
}
```

it should return **"ExampleTest"**