### PR TITLE
fix: only check java file paths

### DIFF
--- a/lua/neotest-java/core/file_checker.lua
+++ b/lua/neotest-java/core/file_checker.lua
@@ -46,6 +46,9 @@ end
 ---@param file_path string
 ---@return boolean
 function FileChecker.is_test_file(file_path)
+	if not vim.endswith(file_path, ".java") then
+		return false
+	end
 	return fileNameMatchesPattern(file_path)
 		or (packagePathMatchesPattern(file_path) and fileBodyContainsPattern(file_path))
 end


### PR DESCRIPTION
This PR add a small check to only try and read files that end with .java. 

This not only improves performance slightly, but also ensures that the file check does not error unexpectedly because of other adapters for other filetypes.