### PR TITLE
refactor: invert depencencies for root_finder

### DIFF
--- a/lua/neotest-java/core/root_finder.lua
+++ b/lua/neotest-java/core/root_finder.lua
@@ -1,4 +1,3 @@
-local lib = require("neotest.lib")
 local log = require("neotest-java.logger")
 
 local RootFinder = {}
@@ -7,17 +6,18 @@ local RootFinder = {}
 ---Should no root be found, the adapter can still be used in a non-project context if a test file matches.
 ---@async
 ---@param dir string @Directory to treat as cwd
+---@param matcher fun(pattern: string): fun(dir: string): string | nil
 ---@return string | nil @Absolute root dir of test suite
-function RootFinder.find_root(dir)
-	local matchers = {
+function RootFinder.find_root(dir, matcher)
+	local patterns = {
 		"pom.xml",
 		"build.gradle",
 		"build.gradle.kts",
 		".git",
 	}
 
-	for _, matcher in ipairs(matchers) do
-		local root = lib.files.match_root_pattern(matcher)(dir)
+	for _, m in ipairs(patterns) do
+		local root = matcher(m)(dir)
 
 		if root then
 			log.debug("Found root: " .. root)

--- a/lua/neotest-java/init.lua
+++ b/lua/neotest-java/init.lua
@@ -8,6 +8,7 @@ local spec_builder = require("neotest-java.core.spec_builder")
 local result_builder = require("neotest-java.core.result_builder")
 local log = require("neotest-java.logger")
 local ch = require("neotest-java.context_holder")
+local lib = require("neotest.lib")
 
 local detect_project_type = require("neotest-java.util.detect_project_type")
 
@@ -31,7 +32,7 @@ local NeotestJavaAdapter = {
 	discover_positions = position_discoverer.discover_positions,
 	results = result_builder.build_results,
 	root = function(dir)
-		local root = root_finder.find_root(dir)
+		local root = root_finder.find_root(dir, lib.files.match_root_pattern)
 		if root then
 			ch.set_root(root)
 		end

--- a/tests/core/root_finder_spec.lua
+++ b/tests/core/root_finder_spec.lua
@@ -1,91 +1,35 @@
-local plugin = require("neotest-java")
-
-local function getCurrentDir()
-	return vim.fn.fnamemodify(vim.fn.expand("%:p:h"), ":p")
-end
+local root_finder = require("neotest-java.core.root_finder")
 
 describe("RootFinder", function()
-	it("should find the root of a maven project", function()
+	it("should find the root when matcher matches", function()
 		-- given
-		local relativeDirs = {
-			"tests/fixtures/maven-demo/src/main/java/com/example",
-			"tests/fixtures/maven-demo/src/test/java/com/example",
-			"tests/fixtures/maven-demo/src/main/resources",
-			"tests/fixtures/maven-demo/src/test/resources",
-			"tests/fixtures/maven-demo/src/main/java/com/example/Example.java",
-			"tests/fixtures/maven-demo/src/test/java/com/example/ExampleTest.java",
-			"tests/fixtures/maven-demo",
-		}
-
-		local absoluteDirs = {}
-		for i, dir in ipairs(relativeDirs) do
-			absoluteDirs[i] = getCurrentDir() .. dir
+		local function matcher()
+			return function(dir)
+				return dir
+			end
 		end
-
-		local expectedRoot = getCurrentDir() .. "tests/fixtures/maven-demo"
+		local dir = "example/dir"
 
 		-- when
-		for _, dir in ipairs(absoluteDirs) do
-			local actualRoot = plugin.root(dir)
+		local actualRoot = root_finder.find_root(dir, matcher)
 
-			-- then
-			assert.are.same(expectedRoot, actualRoot)
-		end
+		-- then
+		assert.are.same(dir, actualRoot)
 	end)
 
-	it("should find the root of a gradle gradle project", function()
+	it("should not find the root when matcher does not match", function()
 		-- given
-		local relativeDirs = {
-			"tests/fixtures/gradle-groovy-demo/src/main/java/com/example",
-			"tests/fixtures/gradle-groovy-demo/src/test/java/com/example",
-			"tests/fixtures/gradle-groovy-demo/src/main/resources",
-			"tests/fixtures/gradle-groovy-demo/src/test/resources",
-			"tests/fixtures/gradle-groovy-demo/src/main/java/com/example/Example.java",
-			"tests/fixtures/gradle-groovy-demo/src/test/java/com/example/ExampleTest.java",
-			"tests/fixtures/gradle-groovy-demo",
-		}
-
-		local absoluteDirs = {}
-		for i, dir in ipairs(relativeDirs) do
-			absoluteDirs[i] = getCurrentDir() .. dir
+		local function matcher()
+			return function()
+				return nil
+			end
 		end
-
-		local expectedRoot = getCurrentDir() .. "tests/fixtures/gradle-groovy-demo"
+		local dir = "example/dir"
 
 		-- when
-		for _, dir in ipairs(absoluteDirs) do
-			local actualRoot = plugin.root(dir)
+		local actualRoot = root_finder.find_root(dir, matcher)
 
-			-- then
-			assert.are.same(expectedRoot, actualRoot)
-		end
+		-- then
+		assert.is_nil(actualRoot)
 	end)
-
-	-- given
-	local relativeDirs = {
-		"tests/fixtures/gradle-kotlin-demo/src/main/java/com/example",
-		"tests/fixtures/gradle-kotlin-demo/src/test/java/com/example",
-		"tests/fixtures/gradle-kotlin-demo/src/main/resources",
-		"tests/fixtures/gradle-kotlin-demo/src/test/resources",
-		"tests/fixtures/gradle-kotlin-demo/src/main/java/com/example/Example.java",
-		"tests/fixtures/gradle-kotlin-demo/src/test/java/com/example/ExampleTest.java",
-		"tests/fixtures/gradle-kotlin-demo",
-	}
-
-	local absoluteDirs = {}
-	for i, dir in ipairs(relativeDirs) do
-		absoluteDirs[i] = getCurrentDir() .. dir
-	end
-
-	local expectedRoot = getCurrentDir() .. "tests/fixtures/gradle-kotlin-demo"
-
-	-- when
-	for _, dir in ipairs(absoluteDirs) do
-		it("should find the root of a gradle kotlin project: " .. dir, function()
-			local actualRoot = plugin.root(dir)
-
-			-- then
-			assert.are.same(expectedRoot, actualRoot)
-		end)
-	end
 end)


### PR DESCRIPTION
Refactored the `root_finder.find_root` function to accept a matcher function as a second argument, inverting the dependency. Updated the corresponding call in `init.lua` to pass the matcher function. Adjusted tests to reflect the new function signature.