### PR TITLE
feat: add support for Ant projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ![image](https://github.com/user-attachments/assets/d1d77980-faab-4110-9b7c-ae6911a3d42c)
 
 ## ⭐ Features
-- ✅ Maven and Gradle projects
+- ✅ Maven, Gradle, and Ant projects
 - ✅ Multimodule projects
 - ✅ Debugging tests with [`nvim-dap`](https://github.com/mfussenegger/nvim-dap)
 

--- a/lua/neotest-java/build_tool/ant.lua
+++ b/lua/neotest-java/build_tool/ant.lua
@@ -1,0 +1,18 @@
+local compatible_path = require("neotest-java.util.compatible_path")
+
+local PROJECT_FILE = "build.xml"
+
+---@class neotest-java.AntBuildTool : neotest-java.BuildTool
+local ant = {}
+
+ant.get_output_dir = function(root)
+	root = root and root or "."
+	return compatible_path(root .. "/build/classes")
+end
+
+function ant.get_project_filename()
+	return PROJECT_FILE
+end
+
+---@type neotest-java.BuildTool
+return ant

--- a/lua/neotest-java/build_tool/init.lua
+++ b/lua/neotest-java/build_tool/init.lua
@@ -1,5 +1,6 @@
 local maven = require("neotest-java.build_tool.maven")
 local gradle = require("neotest-java.build_tool.gradle")
+local ant = require("neotest-java.build_tool.ant")
 local log = require("neotest-java.logger")
 local nio = require("nio")
 local Job = require("plenary.job")
@@ -11,7 +12,7 @@ local lib = require("neotest.lib")
 ---@field get_module_dependencies fun(root: string): table
 
 ---@type table<string, neotest-java.BuildTool>
-local build_tools = { gradle = gradle, maven = maven }
+local build_tools = { gradle = gradle, maven = maven, ant = ant }
 
 --- will determine the build tool to use
 ---@return neotest-java.BuildTool

--- a/lua/neotest-java/util/detect_project_type.lua
+++ b/lua/neotest-java/util/detect_project_type.lua
@@ -1,15 +1,22 @@
 local compatible_path = require("neotest-java.util.compatible_path")
+local maven = require("neotest-java.build_tool.maven")
+local gradle = require("neotest-java.build_tool.gradle")
+local ant = require("neotest-java.build_tool.ant")
 --- @param project_root_path string
---- @return string "gradle" | "maven" | "unknown"
+--- @return string "gradle" | "maven" | "ant" | "unknown"
 local function detect_project_type(project_root_path)
-	local gradle_kotlin_build_file = compatible_path(project_root_path .. "/build.gradle.kts")
-	local gradle_groovy_build_file = compatible_path(project_root_path .. "/build.gradle")
-	local maven_build_file = compatible_path(project_root_path .. "/pom.xml")
+	local gradle_kotlin_build_file =
+		compatible_path(project_root_path .. "/" .. gradle.get_project_filename() .. ".kts")
+	local gradle_groovy_build_file = compatible_path(project_root_path .. "/" .. gradle.get_project_filename())
+	local maven_build_file = compatible_path(project_root_path .. "/" .. maven.get_project_filename())
+	local ant_build_file = compatible_path(project_root_path .. "/" .. ant.get_project_filename())
 
 	if vim.fn.filereadable(gradle_groovy_build_file) == 1 or vim.fn.filereadable(gradle_kotlin_build_file) == 1 then
 		return "gradle"
 	elseif vim.fn.filereadable(maven_build_file) == 1 then
 		return "maven"
+	elseif vim.fn.filereadable(ant_build_file) == 1 then
+		return "ant"
 	end
 
 	return "unknown"


### PR DESCRIPTION
### Description
This pull request introduces support for Ant-based Java projects in the `neotest-java` adapter.

### Motivation
I often work with Ant-based projects, and this plugin makes testing them incredibly easy.
 
### Changes
- Added `ant.lua` to handle Ant-based project configurations.
- Updated the `build_tools` initialization to include Ant as a valid build tool.
- Enhanced the project type detection to use build tools configurations for detecting project types.
- Updated `README.md`

### Testing
I have tested this feature with an Ant-based Java project, ensuring that tests can be run successfully using the `neotest-java` adapter.