### PR TITLE
fix: detect gradle project by settings file

### DIFF
--- a/lua/neotest-java/util/detect_project_type.lua
+++ b/lua/neotest-java/util/detect_project_type.lua
@@ -2,11 +2,14 @@ local compatible_path = require("neotest-java.util.compatible_path")
 --- @param project_root_path string
 --- @return string "gradle" | "maven" | "unknown"
 local function detect_project_type(project_root_path)
-	local gradle_kotlin_build_file = compatible_path(project_root_path .. "/build.gradle.kts")
-	local gradle_groovy_build_file = compatible_path(project_root_path .. "/build.gradle")
+	local gradle_kotlin_settings_file = compatible_path(project_root_path .. "/settings.gradle.kts")
+	local gradle_groovy_settings_file = compatible_path(project_root_path .. "/settings.gradle")
 	local maven_build_file = compatible_path(project_root_path .. "/pom.xml")
 
-	if vim.fn.filereadable(gradle_groovy_build_file) == 1 or vim.fn.filereadable(gradle_kotlin_build_file) == 1 then
+	if
+		vim.fn.filereadable(gradle_groovy_settings_file) == 1
+		or vim.fn.filereadable(gradle_kotlin_settings_file) == 1
+	then
 		return "gradle"
 	elseif vim.fn.filereadable(maven_build_file) == 1 then
 		return "maven"


### PR DESCRIPTION
Not every gradle project contains the build.gradle file in its base. Should detect on settings file instead.

Fixes #184