### PR TITLE
fix: only ignore the main directory files

### DIFF
--- a/lua/neotest-java/core/file_checker.lua
+++ b/lua/neotest-java/core/file_checker.lua
@@ -6,7 +6,7 @@ local FileChecker = {}
 ---@param file_path string
 ---@return boolean
 function FileChecker.is_test_file(file_path)
-	if string.find(file_path, "main/") then
+	if string.find(file_path, "/main/") then
 		return false
 	end
 	for _, pattern in ipairs(JAVA_TEST_FILE_PATTERNS) do

--- a/tests/core/dir_filter_spec.lua
+++ b/tests/core/dir_filter_spec.lua
@@ -35,6 +35,7 @@ describe("DirFilter", function()
 			"src/test/java/com/example/Example.java",
 			"src/test/java/com/example/ExampleTest.java",
 			"src/test/java/com/example/resources/ExampleSpec.java",
+			"src/test/java/com/example/domain/resources/ExampleSpec.java",
 		}
 
 		local root = "/home/user/project"

--- a/tests/core/file_checker_spec.lua
+++ b/tests/core/file_checker_spec.lua
@@ -8,6 +8,7 @@ describe("file_checker", function()
 			"src/test/java/neotest/RepositoryTests.java",
 			"src/test/java/neotest/NeotestIT.java",
 			"src/test/java/neotest/ProductAceptanceTests.java",
+			"src/test/java/neotest/domain/ProductAceptanceTests.java",
 		}
 
 		for _, file_path in ipairs(test_files) do


### PR DESCRIPTION
So I had a project where we have a package named "domain" and the pattern just ignored all our test files in that package.
I have a fix for that it should work if we assume we always have everything in a sub directory like "src".