### PR TITLE
fix: correct junit command classpath and selector arguments

### DIFF
--- a/lua/neotest-java/command/jdtls.lua
+++ b/lua/neotest-java/command/jdtls.lua
@@ -105,11 +105,9 @@ M.get_classpath = function(additional_classpath_entries, dir)
 end
 
 M.get_classpath_file_argument = function(report_dir, additional_classpath_entries, dir)
-	local classpath = table.concat(M.get_classpath(additional_classpath_entries, dir), ":")
-	local temp_file = compatible_path(report_dir .. "/.cp")
-	write_file(temp_file, ("-cp %s"):format(classpath))
-
-	return ("@%s"):format(temp_file)
+	local classpaths = M.get_classpath(additional_classpath_entries, dir)
+	local classpath = table.concat(classpaths, ":")
+	return classpath
 end
 
 return M

--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -99,11 +99,15 @@ local CommandBuilder = {
 		local selectors = {}
 		for _, v in ipairs(self._test_references) do
 			if v.type == "test" then
-				table.insert(selectors, "--select-method='" .. v.qualified_name .. "'")
+				local class_name = v.qualified_name:match("^(.-)#") or v.qualified_name
+				table.insert(selectors, "--select-class=" .. class_name)
+				if v.method_name then
+					table.insert(selectors, "--select-method=" .. v.method_name)
+				end
 			elseif v.type == "file" then
 				table.insert(selectors, "-c=" .. v.qualified_name)
 			elseif v.type == "dir" then
-				selectors = "-p=" .. v.qualified_name
+				table.insert(selectors, "-p=" .. v.qualified_name)
 			end
 		end
 		assert(#selectors ~= 0, "junit command has to have a selector")
@@ -115,7 +119,7 @@ local CommandBuilder = {
 				"-jar",
 				self._junit_jar,
 				"execute",
-				("%s"):format(self._classpath_file_arg),
+				"--classpath=" .. self._classpath_file_arg,
 				"--reports-dir=" .. self._reports_dir,
 				"--fail-if-no-tests",
 				"--disable-banner",


### PR DESCRIPTION
Updated classpath handling to pass directly instead of via temp file, and fixed test selectors to use separate class and method arguments for proper junit execution.

Closes #211