### PR TITLE
fix: improve DAP configuration for debugging from test summary

### DIFF
--- a/lua/neotest-java/core/spec_builder/init.lua
+++ b/lua/neotest-java/core/spec_builder/init.lua
@@ -84,15 +84,18 @@ function SpecBuilder.build_spec(args, project_type, config)
 		logger.debug("junit debug command: ", junit.command, " ", table.concat(junit.args, " "))
 		local terminated_command_event = build_tools.launch_debug_test(junit.command, junit.args)
 
+		local project_name = vim.fn.fnamemodify(root, ":t")
 		return {
 			strategy = {
 				type = "java",
 				request = "attach",
 				name = ("neotest-java (on port %s)"):format(port),
+				host = "localhost",
 				port = port,
+				projectName = project_name,
 			},
 			cwd = root,
-			symbol = position.name,
+			symbol = position.type == "test" and position.name or nil,
 			context = {
 				strategy = args.strategy,
 				reports_dir = reports_dir,


### PR DESCRIPTION
- Add host and projectName to DAP strategy for proper Java attach mode
- Conditionally set symbol only for test positions to prevent invalid main class
- Fixes classpath resolution errors when debugging multiple tests