### PR TITLE
Fix string escaping in junit_command_builder.lua

### DIFF
--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -100,9 +100,9 @@ local CommandBuilder = {
 		for _, v in ipairs(self._test_references) do
 			if v.type == "test" then
 				local class_name = v.qualified_name:match("^(.-)#") or v.qualified_name
-				table.insert(selectors, "--select-class=" .. class_name)
+				table.insert(selectors, "--select-class='" .. class_name .. "'")
 				if v.method_name then
-					table.insert(selectors, "--select-method=" .. v.method_name)
+					table.insert(selectors, "--select-method='" .. v.method_name .. "'")
 				end
 			elseif v.type == "file" then
 				table.insert(selectors, "-c=" .. v.qualified_name)


### PR DESCRIPTION
When there is a `nested` **test** the command line **fails** because the `$` characters.

Example:

It fails ❌

``
--selector-class=Foo$Bar
``

It runs correctly ✅:
``
--selector-class='Foo$Bar'
``

The usage of single quote was removed from previous version here: https://github.com/rcasia/neotest-java/pull/212/files#diff-9c88462a7df8f7c7dd964eea48d80dfbd04d197224657ad2f15981e8f59eedbdL102