### PR TITLE
fix: Using different selectors for debug runs

### DIFF
--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -95,22 +95,23 @@ CommandBuilder.build_junit = function(self, port)
 	assert(self._classpath_file_arg, "classpath_file_arg cannot be nil")
 	assert(self._spring_property_filepaths, "_spring_property_filepaths cannot be nil")
 
+	local function quote_selector(selector_value, is_debug_mode)
+		-- In debug mode, commands are executed via vim.loop.spawn which doesn't
+		-- strip quotes or expand shell variables, so we must not quote the selectors.
+		-- In normal mode, commands are executed through a shell where quotes
+		-- are needed to prevent $ expansion in inner class names
+		if is_debug_mode then
+			return selector_value
+		end
+		return "'" .. selector_value .. "'"
+	end
+
 	local selectors = {}
 	for _, v in ipairs(self._test_references) do
-		-- debug mode is executed through vim.loop.spawn, which is not sensitive to $ and quotes
-		-- passing class/method names with quotes will break name resolution as they won't be stripped
 		if v.type == "method" then
-			if port then
-				table.insert(selectors, "--select-method=" .. v.qualified_name)
-			else
-				table.insert(selectors, "--select-method='" .. v.qualified_name .. "'")
-			end
+			table.insert(selectors, "--select-method=" .. quote_selector(v.qualified_name, port ~= nil))
 		else
-			if port then
-				table.insert(selectors, "--select-class=" .. v.qualified_name)
-			else
-				table.insert(selectors, "--select-class='" .. v.qualified_name .. "'")
-			end
+			table.insert(selectors, "--select-class=" .. quote_selector(v.qualified_name, port ~= nil))
 		end
 	end
 	assert(#selectors ~= 0, "junit command has to have a selector")


### PR DESCRIPTION
When debugging a test, I was getting an error in the neovim messages stating that the output folder for the test was not found. Inspecting the neotest-java logs, I found that the problem was actually junit failing to launch completely due to not finding the desired test:
```
DEBUG | 2026-01-21T17:22:22Z+0100 | ...st-java.nvim/lua/neotest-java/core/spec_builder/init.lua:103 | junit debug command:
/usr/lib/jvm/java-21-openjdk-amd64/bin/java  [...] -jar [path to standalone jar] execute [...] 
--select-method='it.unive.lisa.program.cfg.fixpoints.OptimizedFixpointTest#testCyclicGraph()'

ERROR | 2026-01-21T17:22:28Z+0100 | ...s/neotest-java.nvim/lua/neotest-java/build_tool/init.lua:74 | stderr:  
org.junit.platform.commons.JUnitException: TestEngine with ID 'junit-jupiter' failed to discover tests
	[...]
Caused by: java.lang.ClassNotFoundException: 'it.unive.lisa.program.cfg.fixpoints.OptimizedFixpointTest
	[...]
```
With the red herring being the single quote at the beginning of the class name. Note that, excluding the -agentlib and the -Xdebug parameters, the command line was identical (classpath included) to the one used for running the test normally, which succeeded.

Single quotes were added for #216, since the `$` used for inner classes was being expanded to a variable by the shell spawned for running the test. However, after some digging, I found out that the `plenary.Job` instance does not spawn a native shell, but instead uses `vim.loop.spawn`. This means that it does not perform either variable expansion or single/double quotes removal, and thus the error above.

I added a switch on the generation of the test selector that adds the quotes only in a non-dap execution, which fixes the problem.
