### PR TITLE
refactor: apply dependency injection to three side-effectful modules

### DIFF
--- a/lua/neotest-java/core/result_builder.lua
+++ b/lua/neotest-java/core/result_builder.lua
@@ -2,7 +2,7 @@ local xml = require("neotest.lib.xml")
 local flat_map = require("neotest-java.util.flat_map")
 local log = require("neotest-java.logger")
 local lib = require("neotest.lib")
-local JunitResult = require("neotest-java.model.junit_result")
+local JunitResultFactory = require("neotest-java.model.junit_result")
 local dir_scan = require("neotest-java.util.dir_scan")
 
 local REPORT_FILE_NAMES_PATTERN = "TEST-.+%.xml$"
@@ -49,7 +49,7 @@ local function load_all_testcases(paths, read_file)
 end
 
 --- @return table <string, neotest-java.JunitResult[]>
-local function group_by_method_base(testcases)
+local function group_by_method_base(testcases, JunitResult)
 	local groups = {}
 	for _, tc in ipairs(testcases) do
 		local jres = JunitResult:new(tc)
@@ -70,7 +70,9 @@ local ResultBuilder = {}
 --- @param remove_file? fun(filepath: string): boolean, string? Function to remove a file, returns success, error
 --- @param tree neotest.Tree
 --- @param scan fun(dir: neotest-java.Path, opts: { search_patterns: string[] }): string[]
-function ResultBuilder.build_results(spec, result, tree, scan, read_file, remove_file)
+--- @param write_output? fun(data: string): string  injected file writer; defaults to io.open + nio.fn.tempname
+function ResultBuilder.build_results(spec, result, tree, scan, read_file, remove_file, write_output)
+	local JunitResult = JunitResultFactory(write_output and { write_output = write_output } or nil)
 	scan = scan or dir_scan
 	read_file = read_file or require("neotest-java.util.read_file")
 	remove_file = remove_file
@@ -93,7 +95,7 @@ function ResultBuilder.build_results(spec, result, tree, scan, read_file, remove
 
 	local report_files = scan(spec.context.reports_dir, { search_patterns = { REPORT_FILE_NAMES_PATTERN } })
 	local testcases = load_all_testcases(report_files, read_file)
-	local groups = group_by_method_base(testcases)
+	local groups = group_by_method_base(testcases, JunitResult)
 
 	local results = {}
 

--- a/lua/neotest-java/core/spec_builder/compiler/client_provider.lua
+++ b/lua/neotest-java/core/spec_builder/compiler/client_provider.lua
@@ -1,76 +1,98 @@
 local Path = require("neotest-java.model.path")
 local nio = require("nio")
 
---- @param bufnr number | nil
---- @return vim.lsp.Client
-local function get_client(bufnr)
-	local client_future = nio.control.future()
-	nio.run(function()
-		local clients = vim.lsp.get_clients({ name = "jdtls", bufnr = bufnr })
-		client_future.set(clients and clients[1])
-	end)
-	return client_future:wait()
-end
+--- @class neotest-java.ClientProvider.Deps
+--- @field get_clients? fun(opts: table): vim.lsp.Client[]
+--- @field buf_add? fun(path: string): number
+--- @field buf_load? fun(path: string)
+--- @field hrtime? fun(): number  returns current time in milliseconds
+--- @field globpath? fun(path: string, pattern: string, nosuf: boolean, list: boolean): string[]
 
---- @param dir neotest-java.Path
---- @return neotest-java.Path
-local function find_any_java_file(dir)
-	return Path(
-		assert(
-			vim.iter(nio.fn.globpath(dir:to_string(), Path("**/*.java"):to_string(), false, true)):next(),
-			"No Java file found in the directory." .. dir:to_string()
-		)
-	)
-end
-
---- @param path neotest-java.Path
---- @return number bufnr
-local function preload_file_for_lsp(path)
-	local buf = vim.fn.bufadd(path:to_string()) -- allocates buffer ID
-	vim.fn.bufload(path:to_string()) -- preload lines
-
-	return buf
-end
-
-local function wait(timeout_ms, condition, interval_ms)
-	local start_time = vim.uv.hrtime() / 1e6
-	while true do
-		if condition() then
-			return true
-		end
-
-		local current_time = vim.uv.hrtime() / 1e6
-		if (current_time - start_time) > timeout_ms then
-			return false
-		end
-
-		nio.sleep(interval_ms)
+--- @param deps? neotest-java.ClientProvider.Deps
+--- @return fun(cwd: neotest-java.Path): vim.lsp.Client
+local ClientProvider = function(deps)
+	deps = deps or {}
+	local _get_clients = deps.get_clients or function(opts)
+		return vim.lsp.get_clients(opts)
 	end
-end
-
-local client
---- @param cwd neotest-java.Path
---- @return vim.lsp.Client
-local client_provider = function(cwd)
-	if client and client.initialized then
-		return client
+	local _buf_add = deps.buf_add or vim.fn.bufadd
+	local _buf_load = deps.buf_load or vim.fn.bufload
+	local _hrtime = deps.hrtime or function()
+		return vim.uv.hrtime() / 1e6
 	end
-	client = get_client()
+	local _globpath = deps.globpath or nio.fn.globpath
 
-	if not client then
-		local any_java_file = find_any_java_file(cwd)
-		local bufnr = preload_file_for_lsp(any_java_file)
+	--- @param bufnr number | nil
+	--- @return vim.lsp.Client
+	local function get_client(bufnr)
+		local client_future = nio.control.future()
+		nio.run(function()
+			local clients = _get_clients({ name = "jdtls", bufnr = bufnr })
+			client_future.set(clients and clients[1])
+		end)
+		return client_future:wait()
+	end
 
-		assert(
-			wait(10000, function()
-				client = get_client(bufnr)
-				return not not client and not not client.initialized
-			end, 1000),
-			"jdtls client not started in time"
+	--- @param dir neotest-java.Path
+	--- @return neotest-java.Path
+	local function find_any_java_file(dir)
+		return Path(
+			assert(
+				vim.iter(_globpath(dir:to_string(), Path("**/*.java"):to_string(), false, true)):next(),
+				"No Java file found in the directory." .. dir:to_string()
+			)
 		)
 	end
 
-	return client
+	--- @param path neotest-java.Path
+	--- @return number bufnr
+	local function preload_file_for_lsp(path)
+		local buf = _buf_add(path:to_string())
+		_buf_load(path:to_string())
+		return buf
+	end
+
+	local function wait(timeout_ms, condition, interval_ms)
+		local start_time = _hrtime()
+		while true do
+			if condition() then
+				return true
+			end
+
+			local current_time = _hrtime()
+			if (current_time - start_time) > timeout_ms then
+				return false
+			end
+
+			nio.sleep(interval_ms)
+		end
+	end
+
+	local cached_client = nil
+
+	--- @param cwd neotest-java.Path
+	--- @return vim.lsp.Client
+	return function(cwd)
+		if cached_client and cached_client.initialized then
+			return cached_client
+		end
+		cached_client = get_client()
+
+		if not cached_client then
+			local any_java_file = find_any_java_file(cwd)
+			local bufnr = preload_file_for_lsp(any_java_file)
+
+			assert(
+				wait(10000, function()
+					cached_client = get_client(bufnr)
+					return not not cached_client and not not cached_client.initialized
+				end, 1000),
+				"jdtls client not started in time"
+			)
+		end
+
+		return cached_client
+	end
 end
 
-return client_provider
+return ClientProvider

--- a/lua/neotest-java/core/spec_builder/compiler/init.lua
+++ b/lua/neotest-java/core/spec_builder/compiler/init.lua
@@ -1,4 +1,5 @@
-local client_provider = require("neotest-java.core.spec_builder.compiler.client_provider")
+local nio = require("nio")
+local ClientProvider = require("neotest-java.core.spec_builder.compiler.client_provider")
 local LspCompiler = require("neotest-java.core.spec_builder.compiler.lsp_compiler")
 
 ---@class NeotestJavaCompiler.Opts
@@ -8,6 +9,18 @@ local LspCompiler = require("neotest-java.core.spec_builder.compiler.lsp_compile
 --- Interface for Java compilers
 ---@class NeotestJavaCompiler
 ---@field compile fun(opts: NeotestJavaCompiler.Opts): string classpath_file_arg
+
+local client_provider = ClientProvider({
+	get_clients = function(opts)
+		return vim.lsp.get_clients(opts)
+	end,
+	buf_add = vim.fn.bufadd,
+	buf_load = vim.fn.bufload,
+	hrtime = function()
+		return vim.uv.hrtime() / 1e6
+	end,
+	globpath = nio.fn.globpath,
+})
 
 ---@type table<string, NeotestJavaCompiler>
 local compilers = {

--- a/lua/neotest-java/init.lua
+++ b/lua/neotest-java/init.lua
@@ -33,7 +33,7 @@ local exists = require("neotest.lib.file").exists
 
 local DEFAULT_CONFIG = require("neotest-java.default_config")
 
-local client_provider = require("neotest-java.core.spec_builder.compiler.client_provider")
+local ClientProvider = require("neotest-java.core.spec_builder.compiler.client_provider")
 local MethodIdResolver = require("neotest-java.method_id_resolver")
 local ClasspathProvider = require("neotest-java.core.spec_builder.compiler.classpath_provider")
 local CommandExecutor = require("neotest-java.command.command_executor")
@@ -63,6 +63,7 @@ end
 --- @class neotest-java.Dependencies
 ---@field root_finder? { find_root: fun(dir: string): string | nil }
 ---@field check_junit_jar_deps? neotest-java.CheckJunitJarDeps
+---@field client_provider? fun(cwd: neotest-java.Path): vim.lsp.Client
 
 --- @param config neotest-java.ConfigOpts
 --- @param deps? neotest-java.Dependencies
@@ -72,6 +73,18 @@ local function NeotestJavaAdapter(config, deps)
 	deps = deps or {}
 	local _root_finder = deps and deps.root_finder or root_finder
 	local check_junit_jar_deps = deps.check_junit_jar_deps or {}
+	local client_provider = deps.client_provider
+		or ClientProvider({
+			get_clients = function(opts)
+				return vim.lsp.get_clients(opts)
+			end,
+			buf_add = vim.fn.bufadd,
+			buf_load = vim.fn.bufload,
+			hrtime = function()
+				return vim.uv.hrtime() / 1e6
+			end,
+			globpath = nio.fn.globpath,
+		})
 
 	log.info("neotest-java adapter initialized")
 

--- a/lua/neotest-java/method_id_resolver.lua
+++ b/lua/neotest-java/method_id_resolver.lua
@@ -20,10 +20,8 @@ local MethodIdResolver = function(deps)
 			end
 			local classpath = classpaths[module_dir:to_string()]
 
-			local result = deps.command_executor.execute_command(
-				"bash",
-				{ "-c", javap_path:to_string() .. " -cp '" .. classpath .. "' '" .. classname .. "'" }
-			)
+			local result =
+				deps.command_executor.execute_command(javap_path:to_string(), { "-cp", classpath, classname })
 
 			assert(
 				result.exit_code == 0,

--- a/lua/neotest-java/model/junit_result.lua
+++ b/lua/neotest-java/model/junit_result.lua
@@ -7,274 +7,280 @@ local SKIPPED = require("neotest.types").ResultStatus.skipped
 local LINE_SEPARATOR = "=================================\n"
 local NEW_LINE = "\n"
 
----@param data string | string[] | table
----@return string | nil filepath
-local function create_file_with_content(data)
-	if not data then
-		return nil
-	end
+--- @class neotest-java.JunitResult.Deps
+--- @field write_output? fun(data: string): string  writes data to a temp file and returns its path
 
-	if type(data) == "table" then
-		if #data == 0 then
+--- @param deps? neotest-java.JunitResult.Deps
+--- @return neotest-java.JunitResult
+local JunitResultFactory = function(deps)
+	local _write_output = (deps and deps.write_output)
+		or function(data)
+			local filepath = nio.fn.tempname()
+			nio.run(function()
+				local file = assert(io.open(filepath, "w"))
+				file:write(data)
+				file:close()
+			end)
+			return filepath
+		end
+
+	---@param data string | string[] | table
+	---@return string | nil filepath
+	local function create_file_with_content(data)
+		if not data then
 			return nil
 		end
-		data = vim.iter(vim.tbl_values(data)):flatten(math.huge):totable()
-		data = table.concat(data, LINE_SEPARATOR)
+
+		if type(data) == "table" then
+			if #data == 0 then
+				return nil
+			end
+			data = vim.iter(vim.tbl_values(data)):flatten(math.huge):totable()
+			data = table.concat(data, LINE_SEPARATOR)
+		end
+
+		return _write_output(data)
 	end
 
-	-- Generate a unique temporary file name
-	local filepath = nio.fn.tempname()
+	---@class neotest-java.JunitResult
+	---@field testcase table
+	local JunitResult = {}
 
-	nio.run(function()
-		-- Open the file in write mode
-		local file = assert(io.open(filepath, "w"))
+	---@return neotest.Result
+	function JunitResult.SKIPPED(id)
+		return {
+			status = SKIPPED,
+			output = create_file_with_content({ id, "This test was not executed." }),
+		}
+	end
 
-		file:write(data)
+	---@return neotest.Result
+	function JunitResult.ERROR(id, output)
+		return {
+			status = "failed",
+			output = output or create_file_with_content({ id, "This test execution had an unexpected error." }),
+		}
+	end
 
-		-- Close the file
-		file:close()
-	end)
+	function JunitResult:new(testcase)
+		self.__index = self
+		return setmetatable({ testcase = testcase }, self)
+	end
 
-	-- Return the path to the file
-	return filepath
-end
+	function JunitResult:id()
+		local id = self:classname() .. "#" .. self:name()
 
----@class neotest-java.JunitResult
----@field testcase table
-local JunitResult = {}
+		-- exclude iterations from parameterized tests
+		return id:gsub("%s*%[%d+%]$", "")
+	end
 
----@return neotest.Result
-function JunitResult.SKIPPED(id)
-	return {
-		status = SKIPPED,
-		output = create_file_with_content({ id, "This test was not executed." }),
-	}
-end
+	---@return string
+	function JunitResult:name()
+		return self.testcase._attr.name
+	end
 
----@return neotest.Result
-function JunitResult.ERROR(id, output)
-	return {
-		status = "failed",
-		output = output or create_file_with_content({ id, "This test execution had an unexpected error." }),
-	}
-end
+	---@return string
+	function JunitResult:classname()
+		return self.testcase._attr.classname
+	end
 
-function JunitResult:new(testcase)
-	self.__index = self
-	return setmetatable({ testcase = testcase }, self)
-end
+	---@return neotest.ResultStatus
+	---@return table an array-like table containing tables of the form {failure_message: string, failure_output: string}
+	function JunitResult:status()
+		local failed = self.testcase.failure or self.testcase.error
+		-- This is not parsed correctly by the library
+		-- <failure message="expected: &lt;1> but was: &lt;2>" type="org.opentest4j.AssertionFailedError">
+		-- it breaks in the first '>'
+		-- so it does not detect message attribute sometimes
+		if failed and not failed._attr then
+			local failures = {}
+			for i, fail in ipairs(failed) do
+				failures[i] = {
+					failure_message = fail._attr.message or fail._attr.type or "<unknown failure>",
+					failure_output = fail[1],
+				}
+			end
+			return FAILED, failures
+		end
+		if failed and failed._attr then
+			local fail = {
+				failure_message = failed._attr.message or failed._attr.type or "<unknown failure>",
+				failure_output = failed[1],
+			}
+			return FAILED, { fail }
+		end
+		return PASSED
+	end
 
-function JunitResult:id()
-	local id = self:classname() .. "#" .. self:name()
+	---@param with_name_prefix? boolean
+	---@return neotest.Error[] | nil
+	function JunitResult:errors(with_name_prefix)
+		with_name_prefix = with_name_prefix or false
+		local status, failures = self:status()
+		if status == PASSED then
+			return nil
+		end
 
-	-- exclude iterations from parameterized tests
-	return id:gsub("%s*%[%d+%]$", "")
-end
+		local filename = string.match(self:classname(), "[%.]?([%a%$_][%a%d%$_]+)$") .. ".java"
+		local line_searchpattern = string.gsub(filename, "%.", "%%.") .. ":(%d+)%)"
+		local errors = {}
 
----@return string
-function JunitResult:name()
-	return self.testcase._attr.name
-end
+		for i, failure in ipairs(failures) do
+			local line
+			if failure.failure_output then
+				line = string.match(failure.failure_output, line_searchpattern)
+				-- NOTE: errors array is expecting lines properties to be 0 index based
+				line = line and line - 1 or nil
+			end
 
----@return string
-function JunitResult:classname()
-	return self.testcase._attr.classname
-end
+			local failure_message = failure.failure_message
+			if with_name_prefix then
+				failure_message = self:name() .. " -> " .. failure_message
+			end
 
----@return neotest.ResultStatus
----@return table an array-like table containing tables of the form {failure_message: string, failure_output: string}
-function JunitResult:status()
-	local failed = self.testcase.failure or self.testcase.error
-	-- This is not parsed correctly by the library
-	-- <failure message="expected: &lt;1> but was: &lt;2>" type="org.opentest4j.AssertionFailedError">
-	-- it breaks in the first '>'
-	-- so it does not detect message attribute sometimes
-	if failed and not failed._attr then
-		local failures = {}
-		for i, fail in ipairs(failed) do
-			failures[i] = {
-				failure_message = fail._attr.message or fail._attr.type or "<unknown failure>",
-				failure_output = fail[1],
+			errors[i] = { message = failure_message, line = line }
+		end
+
+		return errors
+	end
+
+	---@return string[]
+	function JunitResult:output()
+		local output_lines = {}
+
+		local system_out = self.testcase["system-out"]
+		if system_out then
+			if type(system_out) == "string" then
+				output_lines[#output_lines + 1] = system_out
+			else
+				for _, out in ipairs(system_out) do
+					output_lines[#output_lines + 1] = out
+				end
+			end
+		end
+
+		local system_err = self.testcase["system-err"]
+		if system_err then
+			if #output_lines > 0 then
+				output_lines[#output_lines + 1] = NEW_LINE
+			end
+			output_lines[#output_lines + 1] = "---- SYSTEM ERROR ----\n"
+
+			if type(system_err) == "string" then
+				output_lines[#output_lines + 1] = system_err
+			else
+				for _, err in ipairs(system_err) do
+					output_lines[#output_lines + 1] = err
+				end
+			end
+			output_lines[#output_lines + 1] = NEW_LINE
+		end
+
+		local status, failures = self:status()
+		if status == FAILED then
+			for _, failure in ipairs(failures) do
+				output_lines[#output_lines + 1] = failure.failure_output
+				output_lines[#output_lines + 1] = NEW_LINE
+			end
+		else -- PASSED
+			output_lines[#output_lines + 1] = "Test passed" .. NEW_LINE
+		end
+
+		return output_lines
+	end
+
+	--- Convert neotest-java.JunitResult to neotest.Result
+	--- Each time this function is called, it will create a temporary file with the output content
+	---@return neotest.Result
+	function JunitResult:result()
+		local status, failures = self:status()
+
+		if status == PASSED then
+			return {
+				status = status,
+				output = create_file_with_content(self:output()),
 			}
 		end
-		return FAILED, failures
-	end
-	if failed and failed._attr then
-		local fail = {
-			failure_message = failed._attr.message or failed._attr.type or "<unknown failure>",
-			failure_output = failed[1],
-		}
-		return FAILED, { fail }
-	end
-	return PASSED
-end
 
----@param with_name_prefix? boolean
----@return neotest.Error[] | nil
-function JunitResult:errors(with_name_prefix)
-	with_name_prefix = with_name_prefix or false
-	local status, failures = self:status()
-	if status == PASSED then
-		return nil
-	end
-
-	local filename = string.match(self:classname(), "[%.]?([%a%$_][%a%d%$_]+)$") .. ".java"
-	local line_searchpattern = string.gsub(filename, "%.", "%%.") .. ":(%d+)%)"
-	local errors = {}
-
-	for i, failure in ipairs(failures) do
-		local line
-		if failure.failure_output then
-			line = string.match(failure.failure_output, line_searchpattern)
-			-- NOTE: errors array is expecting lines properties to be 0 index based
-			line = line and line - 1 or nil
-		end
-
-		local failure_message = failure.failure_message
-		if with_name_prefix then
-			failure_message = self:name() .. " -> " .. failure_message
-		end
-
-		errors[i] = { message = failure_message, line = line }
-	end
-
-	return errors
-end
-
----@return string[]
-function JunitResult:output()
-	local output_lines = {}
-
-	local system_out = self.testcase["system-out"]
-	if system_out then
-		if type(system_out) == "string" then
-			output_lines[#output_lines + 1] = system_out
-		else
-			for _, out in ipairs(system_out) do
-				output_lines[#output_lines + 1] = out
+		local failure_message = ""
+		if failures then
+			for i, failure in ipairs(failures) do
+				failure_message = failure_message .. failure.failure_message
+				if i < #failures then
+					failure_message = failure_message .. NEW_LINE
+				end
 			end
 		end
-	end
 
-	local system_err = self.testcase["system-err"]
-	if system_err then
-		if #output_lines > 0 then
-			output_lines[#output_lines + 1] = NEW_LINE
-		end
-		output_lines[#output_lines + 1] = "---- SYSTEM ERROR ----\n"
-
-		if type(system_err) == "string" then
-			output_lines[#output_lines + 1] = system_err
-		else
-			for _, err in ipairs(system_err) do
-				output_lines[#output_lines + 1] = err
-			end
-		end
-		output_lines[#output_lines + 1] = NEW_LINE
-	end
-
-	local status, failures = self:status()
-	if status == FAILED then
-		for _, failure in ipairs(failures) do
-			output_lines[#output_lines + 1] = failure.failure_output
-			output_lines[#output_lines + 1] = NEW_LINE
-		end
-	else -- PASSED
-		output_lines[#output_lines + 1] = "Test passed" .. NEW_LINE
-	end
-
-	return output_lines
-end
-
---- Convert neotest-java.JunitResult to neotest.Result
---- Each time this function is called, it will create a temporary file with the output content
----@return neotest.Result
-function JunitResult:result()
-	local status, failures = self:status()
-
-	if status == PASSED then
 		return {
 			status = status,
+			short = failure_message,
+			errors = self:errors(),
 			output = create_file_with_content(self:output()),
 		}
 	end
 
-	local failure_message = ""
-	if failures then
-		for i, failure in ipairs(failures) do
-			failure_message = failure_message .. failure.failure_message
-			if i < #failures then
-				failure_message = failure_message .. NEW_LINE
-			end
-		end
-	end
-
-	return {
-		status = status,
-		short = failure_message,
-		errors = self:errors(),
-		output = create_file_with_content(self:output()),
-	}
-end
-
----@param results neotest-java.JunitResult[]
----@return neotest.Result
-function JunitResult.merge_results(results)
-	table.sort(results, function(a, b)
-		return a:name() < b:name()
-	end)
-
-	local status = vim.iter(results):any(function(result)
-		return result:status() == FAILED
-	end) and FAILED or PASSED
-
-	local output = vim.iter(results)
-		:map(function(result)
-			return result:output()
+	---@param results neotest-java.JunitResult[]
+	---@return neotest.Result
+	function JunitResult.merge_results(results)
+		table.sort(results, function(a, b)
+			return a:name() < b:name()
 		end)
-		:flatten(math.huge)
-		:totable()
 
-	if status == PASSED then
-		return { status = status, output = create_file_with_content(output) }
-	end
-
-	local errors = vim.iter(results)
-		:map(function(result)
-			return result:errors(true)
-		end)
-		:flatten()
-		:totable()
-
-	local short = vim.iter(results)
-		:filter(function(result)
+		local status = vim.iter(results):any(function(result)
 			return result:status() == FAILED
-		end)
-		:map(function(result)
-			return result:errors(), result:name()
-		end)
-		:map(function(error, name)
-			if #error == 1 then
-				return name .. " -> " .. error[1].message
-			end
+		end) and FAILED or PASSED
 
-			local errs = name .. " -> {" .. NEW_LINE
-			for i, err in ipairs(error) do
-				errs = errs .. err.message
-				if i < #error then
-					errs = errs .. NEW_LINE
+		local output = vim.iter(results)
+			:map(function(result)
+				return result:output()
+			end)
+			:flatten(math.huge)
+			:totable()
+
+		if status == PASSED then
+			return { status = status, output = create_file_with_content(output) }
+		end
+
+		local errors = vim.iter(results)
+			:map(function(result)
+				return result:errors(true)
+			end)
+			:flatten()
+			:totable()
+
+		local short = vim.iter(results)
+			:filter(function(result)
+				return result:status() == FAILED
+			end)
+			:map(function(result)
+				return result:errors(), result:name()
+			end)
+			:map(function(error, name)
+				if #error == 1 then
+					return name .. " -> " .. error[1].message
 				end
-			end
-			return errs .. NEW_LINE .. "}"
-		end)
-		:fold(nil, function(a, b)
-			if not a then
-				return b
-			end
-			return a .. NEW_LINE .. b
-		end)
 
-	return { status = status, errors = errors, short = short, output = create_file_with_content(output) }
+				local errs = name .. " -> {" .. NEW_LINE
+				for i, err in ipairs(error) do
+					errs = errs .. err.message
+					if i < #error then
+						errs = errs .. NEW_LINE
+					end
+				end
+				return errs .. NEW_LINE .. "}"
+			end)
+			:fold(nil, function(a, b)
+				if not a then
+					return b
+				end
+				return a .. NEW_LINE .. b
+			end)
+
+		return { status = status, errors = errors, short = short, output = create_file_with_content(output) }
+	end
+
+	return JunitResult
 end
 
-return JunitResult
+return JunitResultFactory

--- a/tests/e2e/mocks.lua
+++ b/tests/e2e/mocks.lua
@@ -11,18 +11,20 @@ function M.install_mocks(classpath)
 	local is_windows = vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1
 	local path_sep = is_windows and ";" or ":"
 
-	-- Mock the client_provider module - returns a fake client that provides Java home
-	package.loaded["neotest-java.core.spec_builder.compiler.client_provider"] = function(_)
-		return {
-			request = function(_, method, params, callback)
-				if method == "workspace/executeCommand" and params.command == "java.project.getSettings" then
-					-- Return Java home from environment
-					local java_home = vim.env.JAVA_HOME
-					assert(java_home, "JAVA_HOME environment variable must be set")
-					callback(nil, { ["org.eclipse.jdt.ls.core.vm.location"] = java_home })
-				end
-			end,
-		}
+	-- Mock the client_provider module - factory that returns a function(cwd) -> fake client
+	package.loaded["neotest-java.core.spec_builder.compiler.client_provider"] = function(_deps)
+		return function(_cwd)
+			return {
+				request = function(_, method, params, callback)
+					if method == "workspace/executeCommand" and params.command == "java.project.getSettings" then
+						-- Return Java home from environment
+						local java_home = vim.env.JAVA_HOME
+						assert(java_home, "JAVA_HOME environment variable must be set")
+						callback(nil, { ["org.eclipse.jdt.ls.core.vm.location"] = java_home })
+					end
+				end,
+			}
+		end
 	end
 
 	-- Mock classpath provider - returns pre-resolved Maven classpath

--- a/tests/unit/method_id_resolver_spec.lua
+++ b/tests/unit/method_id_resolver_spec.lua
@@ -69,8 +69,8 @@ describe("Method Id Resolver", function()
 
 		eq(1, #fake_command_executor_invocations, "command_executor should be invoked once")
 		eq({
-			command = "bash",
-			args = { "-c", Path("/fake/javap"):to_string() .. " -cp 'my_classpath' 'com.example.ExampleTest'" },
+			command = Path("/fake/javap"):to_string(),
+			args = { "-cp", "my_classpath", "com.example.ExampleTest" },
 		}, fake_command_executor_invocations[1])
 	end)
 

--- a/tests/unit/result_builder_spec.lua
+++ b/tests/unit/result_builder_spec.lua
@@ -1,7 +1,6 @@
 local _ = require("vim.treesitter") -- NOTE: needed for loading treesitter upfront for the tests
 local async = require("nio").tests
 local result_builder = require("neotest-java.core.result_builder")
-local tempname_fn = require("nio").fn.tempname
 local Path = require("neotest-java.model.path")
 local eq = require("tests.assertions").eq
 local TREES = require("tests.trees")
@@ -24,17 +23,13 @@ local DEFAULT_SPEC = {
 
 local tempfiles = {}
 
+-- Stub write_output: always records the path and returns TEMPNAME
+local fake_write_output = function(_data)
+	return TEMPNAME
+end
+
 describe("ResultBuilder", function()
-	async.before_each(function()
-		-- mock the tempname function to return a fixed value
-		require("nio").fn.tempname = function()
-			return TEMPNAME
-		end
-	end)
-
 	async.after_each(function()
-		require("nio").fn.tempname = tempname_fn
-
 		-- remove all temp files
 		for _, path in ipairs(tempfiles) do
 			os.remove(path)
@@ -65,7 +60,15 @@ describe("ResultBuilder", function()
 			-- },
 		}
 		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			nil,
+			fake_write_output
+		)
 
 		-- then
 		assert.are.same(expected, results)
@@ -109,7 +112,15 @@ describe("ResultBuilder", function()
 		}
 
 		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			nil,
+			fake_write_output
+		)
 
 		--then
 		eq(expected, results)
@@ -159,7 +170,15 @@ describe("ResultBuilder", function()
 		}
 
 		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			nil,
+			fake_write_output
+		)
 
 		--then
 		eq(expected, results)
@@ -223,7 +242,15 @@ describe("ResultBuilder", function()
 			},
 		}
 		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			nil,
+			fake_write_output
+		)
 
 		--then
 		eq(expected, results)
@@ -267,7 +294,15 @@ describe("ResultBuilder", function()
 			},
 		}
 		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			nil,
+			fake_write_output
+		)
 
 		--then
 		eq(expected, results)
@@ -308,7 +343,15 @@ describe("ResultBuilder", function()
 		}
 
 		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			nil,
+			fake_write_output
+		)
 
 		--then
 		eq(expected, results)
@@ -363,7 +406,15 @@ describe("ResultBuilder", function()
 		}
 
 		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			nil,
+			fake_write_output
+		)
 
 		--then
 		eq(expected, results)
@@ -416,8 +467,15 @@ describe("ResultBuilder", function()
 		}
 
 		--when
-		local results =
-			result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file, remove_file)
+		local results = result_builder.build_results(
+			DEFAULT_SPEC,
+			SUCCESSFUL_RESULT,
+			tree,
+			scan_dir,
+			read_file,
+			remove_file,
+			fake_write_output
+		)
 
 		--then
 		eq(expected, results)


### PR DESCRIPTION
## Summary

Identified and fixed three cases where hard-coded external API calls prevented unit testing and reduced modularity.

### Case 1 — `client_provider.lua`: factory pattern + injected LSP/buffer APIs

**Problem:** A module-level `local client` mutable variable acted as a global singleton cache shared across all callers, persisting state between test runs. All LSP and buffer calls (`vim.lsp.get_clients`, `vim.fn.bufadd`, `vim.fn.bufload`, `vim.uv.hrtime`, `nio.fn.globpath`) were hard-coded.

**Fix:** Converted to a `ClientProvider(deps)` factory. The client cache is now a closure-local variable, isolated per instance. All external APIs are injectable via a `deps` table with production defaults. Updated `compiler/init.lua` and `init.lua` to wire real deps; updated e2e mock to match the new factory shape.

### Case 2 — `method_id_resolver.lua`: direct `javap` invocation instead of `bash -c`

**Problem:** Even though `command_executor` was injected, the shell binary `"bash"` was hard-coded and `javap` was wrapped in `bash -c "javap -cp '...' '...'"`. This fails on systems without bash (e.g. Windows) and adds unnecessary shell-quoting fragility.

**Fix:** Call `javap` directly as the executable, passing `-cp`, classpath, and classname as separate argv entries — no shell wrapper needed.

### Case 3 — `junit_result.lua`: injectable `write_output` replaces `io.open` + `nio.fn.tempname`

**Problem:** `create_file_with_content` called `nio.fn.tempname()` and `io.open()` directly, making every `JunitResult:result()` and `merge_results()` call write to real disk. Tests worked around this by monkey-patching `nio.fn.tempname` globally in `before_each`.

**Fix:** Converted `JunitResult` to a `JunitResultFactory(deps)` factory accepting an optional `write_output` function. `result_builder.build_results` accepts an optional `write_output` parameter and threads it through. Tests now pass a stub directly — no more global monkey-patching.

## Testing

All unit and e2e tests pass (`make test`).