### PR TITLE
fix: change require_language to language.add

### DIFF
--- a/lua/neotest-java/health.lua
+++ b/lua/neotest-java/health.lua
@@ -7,7 +7,7 @@ local function java_parser_installed()
 	if ok and type(parsers.has_parser) == "function" then
 		return parsers.has_parser("java")
 	end
-	local lang_ok = pcall(vim.treesitter.language.require_language, "java", nil, true)
+	local lang_ok = pcall(vim.treesitter.language.add, "java")
 	return lang_ok
 end
 


### PR DESCRIPTION
`require_language` is deprecated since neovim 0.12 so I have replaced it with `language.add`, which is the new way to do it.