### PR TITLE
refactor(result_builder): convert to DI factory and inject tempname

### DIFF
--- a/lua/neotest-java/core/result_builder.lua
+++ b/lua/neotest-java/core/result_builder.lua
@@ -3,7 +3,6 @@ local flat_map = require("neotest-java.util.flat_map")
 local log = require("neotest-java.logger")
 local lib = require("neotest.lib")
 local JunitResult = require("neotest-java.model.junit_result")
-local dir_scan = require("neotest-java.util.dir_scan")
 
 local REPORT_FILE_NAMES_PATTERN = "TEST-.+%.xml$"
 
@@ -17,7 +16,8 @@ end
 
 --- @param read_file fun(path: neotest-java.Path): string
 --- @param paths string[]
-local function load_all_testcases(paths, read_file)
+--- @param tempname? fun(): string
+local function load_all_testcases(paths, read_file, tempname)
 	log.debug("Found report files: ", paths)
 	if #paths == 0 then
 		return {}
@@ -44,15 +44,19 @@ local function load_all_testcases(paths, read_file)
 		if not vim.isarray(tcs) then
 			tcs = { tcs }
 		end
-		return tcs
+		return vim.iter(tcs)
+			:map(function(tc)
+				return { tc = tc, tempname = tempname }
+			end)
+			:totable()
 	end, paths)
 end
 
 --- @return table <string, neotest-java.JunitResult[]>
 local function group_by_method_base(testcases)
 	local groups = {}
-	for _, tc in ipairs(testcases) do
-		local jres = JunitResult:new(tc)
+	for _, entry in ipairs(testcases) do
+		local jres = JunitResult:new(entry.tc, entry.tempname)
 		local key = jres:id()
 		groups[key] = groups[key] or {}
 		table.insert(groups[key], jres)
@@ -64,74 +68,83 @@ end
 -- Public API
 -- -----------------------------------------------------------------------------
 
-local ResultBuilder = {}
+--- @class neotest-java.ResultBuilder
+--- @field build_results fun(spec: neotest.RunSpec, result: neotest.StrategyResult, tree: neotest.Tree): table<string, neotest.Result>
 
---- @param read_file fun(path: neotest-java.Path): string
---- @param remove_file? fun(filepath: string): boolean, string? Function to remove a file, returns success, error
---- @param tree neotest.Tree
---- @param scan fun(dir: neotest-java.Path, opts: { search_patterns: string[] }): string[]
-function ResultBuilder.build_results(spec, result, tree, scan, read_file, remove_file)
-	scan = scan or dir_scan
-	read_file = read_file or require("neotest-java.util.read_file")
-	remove_file = remove_file
-		or function(filepath)
-			local ok, err = pcall(os.remove, filepath)
-			if not ok then
-				return false, tostring(err)
+--- @class neotest-java.ResultBuilderDeps
+--- @field scan_dir fun(dir: neotest-java.Path, opts: { search_patterns: string[] }): neotest-java.Path[]
+--- @field read_file fun(path: neotest-java.Path): string
+--- @field remove_file fun(filepath: string): boolean, string?
+--- @field tempname_fn fun(): string
+
+--- @param deps neotest-java.ResultBuilderDeps
+--- @return neotest-java.ResultBuilder
+local ResultBuilder = function(deps)
+	deps = deps or {}
+	assert(deps.scan_dir, "scan_dir should not be nil")
+	assert(deps.read_file, "read_file should not be nil")
+	assert(deps.remove_file, "remove_file should not be nil")
+	assert(deps.tempname_fn, "tempname_fn should not be nil")
+
+	return {
+		--- @param spec neotest.RunSpec
+		--- @param result neotest.StrategyResult
+		--- @param tree neotest.Tree
+		--- @return table<string, neotest.Result>
+		build_results = function(spec, result, tree)
+			if result.code ~= 0 and result.code ~= 1 then
+				local node = tree:data()
+				return { [node.id] = JunitResult.ERROR(node.id, result.output, deps.tempname_fn) }
 			end
-			return true
-		end
 
-	if result.code ~= 0 and result.code ~= 1 then
-		local node = tree:data()
-		return { [node.id] = JunitResult.ERROR(node.id, result.output) }
-	end
-
-	if spec.context.strategy == "dap" then
-		spec.context.terminated_command_event.wait()
-	end
-
-	local report_files = scan(spec.context.reports_dir, { search_patterns = { REPORT_FILE_NAMES_PATTERN } })
-	local testcases = load_all_testcases(report_files, read_file)
-	local groups = group_by_method_base(testcases)
-
-	local results = {}
-
-	for id, items in pairs(groups) do
-		if #items == 1 then
-			--- @type neotest-java.JunitResult
-			local jres = items[1]
-
-			results[id] = jres:result()
-		else
-			local _id = vim
-				.iter(tree:iter())
-				--- @param pos neotest.Position
-				:map(function(_, pos)
-					return pos.id
-				end)
-				:find(function(pos_id)
-					return clean_id(pos_id) == clean_id(items[1]:id())
-				end)
-
-			if _id then
-				results[_id] = JunitResult.merge_results(items)
-			else
-				log.error("Could not find matching test node for results with id: " .. items[1]:id())
+			if spec.context.strategy == "dap" then
+				spec.context.terminated_command_event.wait()
 			end
-		end
-	end
 
-	-- Clean up report files after processing
-	for _, report_file in ipairs(report_files) do
-		local filepath = tostring(report_file)
-		local ok, err = remove_file(filepath)
-		if not ok then
-			log.debug("Could not remove report file: " .. filepath .. " - " .. tostring(err or "unknown error"))
-		end
-	end
+			local report_files =
+				deps.scan_dir(spec.context.reports_dir, { search_patterns = { REPORT_FILE_NAMES_PATTERN } })
+			local testcases = load_all_testcases(report_files, deps.read_file, deps.tempname_fn)
+			local groups = group_by_method_base(testcases)
 
-	return results
+			local results = {}
+
+			for id, items in pairs(groups) do
+				if #items == 1 then
+					--- @type neotest-java.JunitResult
+					local jres = items[1]
+
+					results[id] = jres:result()
+				else
+					local _id = vim
+						.iter(tree:iter())
+						--- @param pos neotest.Position
+						:map(function(_, pos)
+							return pos.id
+						end)
+						:find(function(pos_id)
+							return clean_id(pos_id) == clean_id(items[1]:id())
+						end)
+
+					if _id then
+						results[_id] = JunitResult.merge_results(items, deps.tempname_fn)
+					else
+						log.error("Could not find matching test node for results with id: " .. items[1]:id())
+					end
+				end
+			end
+
+			-- Clean up report files after processing
+			for _, report_file in ipairs(report_files) do
+				local filepath = tostring(report_file)
+				local ok, err = deps.remove_file(filepath)
+				if not ok then
+					log.debug("Could not remove report file: " .. filepath .. " - " .. tostring(err or "unknown error"))
+				end
+			end
+
+			return results
+		end,
+	}
 end
 
 return ResultBuilder

--- a/lua/neotest-java/init.lua
+++ b/lua/neotest-java/init.lua
@@ -5,7 +5,7 @@ local root_finder = require("neotest-java.core.root_finder")
 local dir_filter = require("neotest-java.core.dir_filter")
 local PositionDiscoverer = require("neotest-java.core.positions_discoverer")
 local SpecBuilder = require("neotest-java.core.spec_builder")
-local result_builder = require("neotest-java.core.result_builder")
+local ResultBuilder = require("neotest-java.core.result_builder")
 local log = require("neotest-java.logger")
 local ch = require("neotest-java.context_holder")
 local Path = require("neotest-java.model.path")
@@ -229,7 +229,18 @@ local function NeotestJavaAdapter(config, deps)
 				binaries = binaries,
 			}),
 		}).discover_positions,
-		results = result_builder.build_results,
+		results = ResultBuilder({
+			scan_dir = require("neotest-java.util.dir_scan"),
+			read_file = require("neotest-java.util.read_file"),
+			remove_file = function(filepath)
+				local ok, err = pcall(os.remove, filepath)
+				if not ok then
+					return false, tostring(err)
+				end
+				return true
+			end,
+			tempname_fn = require("nio").fn.tempname,
+		}).build_results,
 		root = function(dir)
 			return _root_finder.find_root(dir)
 		end,

--- a/lua/neotest-java/model/junit_result.lua
+++ b/lua/neotest-java/model/junit_result.lua
@@ -8,8 +8,9 @@ local LINE_SEPARATOR = "=================================\n"
 local NEW_LINE = "\n"
 
 ---@param data string | string[] | table
+---@param tempname? fun(): string
 ---@return string | nil filepath
-local function create_file_with_content(data)
+local function create_file_with_content(data, tempname)
 	if not data then
 		return nil
 	end
@@ -23,7 +24,7 @@ local function create_file_with_content(data)
 	end
 
 	-- Generate a unique temporary file name
-	local filepath = nio.fn.tempname()
+	local filepath = (tempname or nio.fn.tempname)()
 
 	nio.run(function()
 		-- Open the file in write mode
@@ -41,27 +42,35 @@ end
 
 ---@class neotest-java.JunitResult
 ---@field testcase table
+---@field tempname? fun(): string
 local JunitResult = {}
 
+---@param id string
+---@param tempname? fun(): string
 ---@return neotest.Result
-function JunitResult.SKIPPED(id)
+function JunitResult.SKIPPED(id, tempname)
 	return {
 		status = SKIPPED,
-		output = create_file_with_content({ id, "This test was not executed." }),
+		output = create_file_with_content({ id, "This test was not executed." }, tempname),
 	}
 end
 
+---@param id string
+---@param output? string
+---@param tempname? fun(): string
 ---@return neotest.Result
-function JunitResult.ERROR(id, output)
+function JunitResult.ERROR(id, output, tempname)
 	return {
 		status = "failed",
-		output = output or create_file_with_content({ id, "This test execution had an unexpected error." }),
+		output = output or create_file_with_content({ id, "This test execution had an unexpected error." }, tempname),
 	}
 end
 
-function JunitResult:new(testcase)
+---@param testcase table
+---@param tempname? fun(): string
+function JunitResult:new(testcase, tempname)
 	self.__index = self
-	return setmetatable({ testcase = testcase }, self)
+	return setmetatable({ testcase = testcase, tempname = tempname }, self)
 end
 
 function JunitResult:id()
@@ -195,7 +204,7 @@ function JunitResult:result()
 	if status == PASSED then
 		return {
 			status = status,
-			output = create_file_with_content(self:output()),
+			output = create_file_with_content(self:output(), self.tempname),
 		}
 	end
 
@@ -213,13 +222,15 @@ function JunitResult:result()
 		status = status,
 		short = failure_message,
 		errors = self:errors(),
-		output = create_file_with_content(self:output()),
+		output = create_file_with_content(self:output(), self.tempname),
 	}
 end
 
 ---@param results neotest-java.JunitResult[]
+---@param tempname? fun(): string
 ---@return neotest.Result
-function JunitResult.merge_results(results)
+function JunitResult.merge_results(results, tempname)
+	tempname = tempname or (results[1] and results[1].tempname)
 	table.sort(results, function(a, b)
 		return a:name() < b:name()
 	end)
@@ -236,7 +247,7 @@ function JunitResult.merge_results(results)
 		:totable()
 
 	if status == PASSED then
-		return { status = status, output = create_file_with_content(output) }
+		return { status = status, output = create_file_with_content(output, tempname) }
 	end
 
 	local errors = vim.iter(results)
@@ -274,7 +285,7 @@ function JunitResult.merge_results(results)
 			return a .. NEW_LINE .. b
 		end)
 
-	return { status = status, errors = errors, short = short, output = create_file_with_content(output) }
+	return { status = status, errors = errors, short = short, output = create_file_with_content(output, tempname) }
 end
 
 return JunitResult

--- a/tests/unit/test_result_builder_spec.lua
+++ b/tests/unit/test_result_builder_spec.lua
@@ -1,6 +1,5 @@
 local _ = require("vim.treesitter") -- NOTE: needed for loading treesitter upfront for the tests
-local result_builder = require("neotest-java.core.result_builder")
-local tempname_fn = require("nio").fn.tempname
+local ResultBuilder = require("neotest-java.core.result_builder")
 local Path = require("neotest-java.model.path")
 local eq = require("tests.assertions").eq
 local TREES = require("tests.trees")
@@ -24,16 +23,11 @@ local DEFAULT_SPEC = {
 local tempfiles = {}
 
 describe("ResultBuilder", function()
-	before_each(function()
-		-- mock the tempname function to return a fixed value
-		require("nio").fn.tempname = function()
-			return TEMPNAME
-		end
-	end)
-
+	local fake_tempname = function()
+		return TEMPNAME
+	end
+	local remove_file = function() end
 	after_each(function()
-		require("nio").fn.tempname = tempname_fn
-
 		-- remove all temp files
 		for _, path in ipairs(tempfiles) do
 			os.remove(path)
@@ -53,21 +47,18 @@ describe("ResultBuilder", function()
 		local file_path = current_dir .. "tests/fixtures/maven-demo/src/test/java/com/example/ExampleTest.java"
 		local tree = TREES.TWO_TESTS_IN_FILE(Path(file_path))
 
-		local expected = {
-			-- ["com.example.ExampleTest#firstTestMethod()"] = {
-			-- 	status = "skipped",
-			-- 	output = TEMPNAME,
-			-- },
-			-- ["com.example.ExampleTest#secondTestMethod()"] = {
-			-- 	status = "skipped",
-			-- 	output = TEMPNAME,
-			-- },
-		}
-		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
+		local expected = {}
 
 		-- then
-		assert.are.same(expected, results)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
 	end)
 
 	it("should build results from report", function()
@@ -95,7 +86,6 @@ describe("ResultBuilder", function()
 
 		local expected = {
 			["com.example.ExampleTest#firstTestMethod()"] = {
-				-- errors = { { line = 13, message = "expected: <true> but was: <false>" } },
 				errors = { { message = "expected: <true> but was: <false>" } },
 				short = "expected: <true> but was: <false>",
 				status = "failed",
@@ -107,11 +97,16 @@ describe("ResultBuilder", function()
 			},
 		}
 
-		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
-
 		--then
-		eq(expected, results)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
 	end)
 
 	it("builds the results for a test that has an error at start", function()
@@ -157,11 +152,16 @@ describe("ResultBuilder", function()
 			},
 		}
 
-		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
-
 		--then
-		eq(expected, results)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
 	end)
 
 	it("builds results for parameterized test with @CsvSource", function()
@@ -201,11 +201,9 @@ describe("ResultBuilder", function()
 			["com.example.ParameterizedMethodTest#parameterizedMethodShouldFail(java.lang.Integer, java.lang.Integer)"] = {
 				errors = {
 					{
-						-- line = 27,
 						message = "parameterizedMethodShouldFail(Integer, Integer)[1] -> expected: <true> but was: <false>",
 					},
 					{
-						-- line = 27,
 						message = "parameterizedMethodShouldFail(Integer, Integer)[2] -> expected: <true> but was: <false>",
 					},
 				},
@@ -221,11 +219,17 @@ describe("ResultBuilder", function()
 				output = TEMPNAME,
 			},
 		}
-		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
 
 		--then
-		eq(expected, results)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
 	end)
 
 	it("builds the results for parameterized with @EmptySource test", function()
@@ -256,7 +260,6 @@ describe("ResultBuilder", function()
 			["com.example.ExampleTest#parameterizedMethodShouldFail(java.lang.Integer, java.lang.Integer)"] = {
 				errors = {
 					{
-						-- line = 22,
 						message = "parameterizedMethodShouldFail(Integer, Integer)[1] -> expected: <false> but was: <true>",
 					},
 				},
@@ -265,11 +268,17 @@ describe("ResultBuilder", function()
 				output = TEMPNAME,
 			},
 		}
-		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
 
 		--then
-		eq(expected, results)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
 	end)
 
 	it("should build results for nested tests", function()
@@ -306,11 +315,16 @@ describe("ResultBuilder", function()
 			},
 		}
 
-		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
-
 		--then
-		eq(expected, results)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
 	end)
 
 	it("should build results with multiple failures", function()
@@ -361,11 +375,16 @@ describe("ResultBuilder", function()
 			},
 		}
 
-		--when
-		local results = result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file)
-
 		--then
-		eq(expected, results)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
 	end)
 
 	it("should remove report files after processing", function()
@@ -384,7 +403,7 @@ describe("ResultBuilder", function()
 		local report_file = Path("/tmp/TEST-ExampleTest.xml")
 
 		local removed_files = {}
-		local remove_file = function(filepath)
+		local tracking_remove_file = function(filepath)
 			table.insert(removed_files, filepath)
 			return true
 		end
@@ -414,14 +433,16 @@ describe("ResultBuilder", function()
 			},
 		}
 
-		--when
-		local results =
-			result_builder.build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree, scan_dir, read_file, remove_file)
-
 		--then
-		eq(expected, results)
-
-		-- Verify remove_file was called with the correct file path
-		assert.are.same({ report_file:to_string() }, removed_files)
+		eq(
+			expected,
+			ResultBuilder({
+				scan_dir = scan_dir,
+				read_file = read_file,
+				remove_file = tracking_remove_file,
+				tempname_fn = fake_tempname,
+			}).build_results(DEFAULT_SPEC, SUCCESSFUL_RESULT, tree)
+		)
+		eq({ report_file:to_string() }, removed_files)
 	end)
 end)


### PR DESCRIPTION
## Summary
- Convert `ResultBuilder` to a dependency-injected factory taking `scan_dir`, `read_file`, `remove_file`, and `tempname_fn`, making it easier to unit test in isolation.
- Wire the factory up in `init.lua` and use `nio.fn.tempname` to avoid `E5560: tempname must not be called in a fast event context` when capturing stdout/stderr into temp files.
- Update unit tests in `tests/unit/test_result_builder_spec.lua` to construct the builder via the new factory and inject fakes.

## Notes
- `JunitResult` now receives `tempname` through the call chain instead of reaching for `vim.fn.tempname` directly.
- No behavior change intended for end users — same XML parsing, same grouping/merging logic, same cleanup of report files.