### PR TITLE
fix(build_tool/init): return the correct build dir name

### DIFF
--- a/lua/neotest-java/build_tool/build_tool.lua
+++ b/lua/neotest-java/build_tool/build_tool.lua
@@ -1,8 +1,6 @@
-local Path = require("neotest-java.model.path")
-
 ---@class neotest-java.BuildToolConfig
 ---@field project_filename string
----@field get_build_dirname fun(base_dir: neotest-java.Path, deps: table): string
+---@field get_build_dirname fun(base_dir: neotest-java.Path, deps: table): neotest-java.Path
 ---@field get_artifact_id fun(base_dir: neotest-java.Path, deps: table): string
 ---@field get_spring_subdirs fun(root: neotest-java.Path): neotest-java.Path[]
 
@@ -18,7 +16,7 @@ local function create_build_tool(config, deps)
 	---@type neotest-java.BuildTool
 	return {
 		get_build_dirname = function(base_dir)
-			return Path(config.get_build_dirname(base_dir, deps))
+			return config.get_build_dirname(base_dir, deps)
 		end,
 
 		get_project_filename = function()

--- a/lua/neotest-java/build_tool/init.lua
+++ b/lua/neotest-java/build_tool/init.lua
@@ -1,5 +1,4 @@
 local create_build_tool = require("neotest-java.build_tool.build_tool")
-local Path = require("neotest-java.model.path")
 local read_xml_tag = require("neotest-java.util.read_xml_tag")
 local generate_spring_property_filepaths = require("neotest-java.util.spring_property_filepaths")
 
@@ -36,7 +35,7 @@ local build_tools = {
 	gradle = create_build_tool({
 		project_filename = "%.gradle",
 		get_build_dirname = function(_base_dir, _d)
-			return Path("bin")
+			return "bin"
 		end,
 		get_artifact_id = function(base_dir, _d)
 			return base_dir:name()

--- a/lua/neotest-java/build_tool/init.lua
+++ b/lua/neotest-java/build_tool/init.lua
@@ -1,4 +1,5 @@
 local create_build_tool = require("neotest-java.build_tool.build_tool")
+local Path = require("neotest-java.model.path")
 local read_xml_tag = require("neotest-java.util.read_xml_tag")
 local generate_spring_property_filepaths = require("neotest-java.util.spring_property_filepaths")
 
@@ -21,7 +22,7 @@ local build_tools = {
 		get_build_dirname = function(base_dir, d)
 			local pom_path = base_dir:append("pom.xml"):to_string()
 			local build_dir = d.read_xml_tag(pom_path, "project.build.directory")
-			return build_dir or "target"
+			return Path(build_dir or "target")
 		end,
 		get_artifact_id = function(base_dir, d)
 			local pom_path = base_dir:append("pom.xml"):to_string()
@@ -35,7 +36,7 @@ local build_tools = {
 	gradle = create_build_tool({
 		project_filename = "%.gradle",
 		get_build_dirname = function(_base_dir, _d)
-			return "bin"
+			return Path("bin")
 		end,
 		get_artifact_id = function(base_dir, _d)
 			return base_dir:name()

--- a/tests/unit/test_gradle_build_tool_spec.lua
+++ b/tests/unit/test_gradle_build_tool_spec.lua
@@ -1,0 +1,21 @@
+local Path = require("neotest-java.model.path")
+local build_tools = require("neotest-java.build_tool")
+
+local assertions = require("tests.assertions")
+local eq = assertions.eq
+local async = require("tests.async_helpers").async
+
+describe("GradleBuildTool", function()
+	local gradle = build_tools.get("gradle")
+
+	describe("get_build_dirname", function()
+		it(
+			"returns bin",
+			async(function()
+				local base_dir = Path("not/used")
+				local result = gradle.get_build_dirname(base_dir)
+				eq(Path("bin"), result)
+			end)
+		)
+	end)
+end)

--- a/tests/unit/test_maven_build_tool_spec.lua
+++ b/tests/unit/test_maven_build_tool_spec.lua
@@ -13,7 +13,7 @@ describe("MavenBuildTool", function()
 		get_build_dirname = function(base_dir, deps)
 			local pom_path = base_dir:append("pom.xml"):to_string()
 			local build_dir = deps.read_xml_tag(pom_path, "project.build.directory")
-			return build_dir or "target"
+			return Path(build_dir or "target")
 		end,
 		get_artifact_id = function(base_dir, deps)
 			local pom_path = base_dir:append("pom.xml"):to_string()


### PR DESCRIPTION
## Description

When I run the tests for a file on my multi-modules gradle java project, I get the following error

```
neotest-java: ...e/nvim/lazy/neotest-java/lua/neotest-java/model/path.lua:61: attempt to call method 'sub' (a nil value)
stack traceback:
	...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:89: in function 'sub'
	...e/nvim/lazy/neotest-java/lua/neotest-java/model/path.lua:61: in function 'get_build_dirname'
	...neotest-java/lua/neotest-java/core/spec_builder/init.lua:63: in function 'build_spec'
	...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:76: in function '_run_tree'
	...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:65: in function <...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:22>
	[C]: in function 'xpcall'
	...ocal/share/nvim/lazy/neotest/lua/neotest/client/init.lua:84: in function 'run_tree'
	...al/share/nvim/lazy/neotest/lua/neotest/consumers/run.lua:85: in function 'func'
	...ocal/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:169: in function <...ocal/share/nvim/lazy/nvim-nio/lua/nio/tasks.lua:168>
```

## Changes

The function `get_build_dirname` is expected to return a `String`, that is then used inside [`create_build_tool`](https://github.com/rcasia/neotest-java/blob/2643f3352a086089c85711221396f66c3cc5d8ae/lua/neotest-java/build_tool/build_tool.lua#L21) to create a `Path`, thus I return a `string` instead