### PR TITLE
fix: wrap classpath LSP requests in vim.schedule

### DIFF
--- a/lua/neotest-java/core/spec_builder/compiler/classpath_provider.lua
+++ b/lua/neotest-java/core/spec_builder/compiler/classpath_provider.lua
@@ -8,9 +8,14 @@ local nio = require("nio")
 --- @field modulepaths string []
 --- @field projectRoot string
 
---- @param deps { client_provider: fun(cwd: neotest-java.Path): vim.lsp.Client }
+--- @class neotest-java.ClasspathProviderDeps
+--- @field client_provider fun(cwd: neotest-java.Path): vim.lsp.Client
+--- @field schedule? fun(fn: fun()) Defaults to vim.schedule. Inject a synchronous pass-through in tests.
+--- @param deps neotest-java.ClasspathProviderDeps
 --- @return neotest-java.ClasspathProvider
+
 local function ClasspathProvider(deps)
+	local schedule = deps.schedule or vim.schedule
 	return {
 		get_classpath = function(base_dir, additional_classpath_entries)
 			additional_classpath_entries = additional_classpath_entries or {}
@@ -26,7 +31,7 @@ local function ClasspathProvider(deps)
 			-- (nio coroutines run as libuv callbacks) so nvim_buf_is_valid,
 			-- called internally by client:request, is safe to invoke. Mirrors
 			-- the fix applied to command/binaries.lua in 7cdd189.
-			vim.schedule(function()
+			schedule(function()
 				client:request("workspace/executeCommand", {
 					command = "java.project.getClasspaths",
 					arguments = { base_dir_uri, vim.json.encode({ scope = "runtime" }) },

--- a/lua/neotest-java/core/spec_builder/compiler/classpath_provider.lua
+++ b/lua/neotest-java/core/spec_builder/compiler/classpath_provider.lua
@@ -22,27 +22,33 @@ local function ClasspathProvider(deps)
 			local runtime = nio.control.future()
 			local test = nio.control.future()
 
-			client:request("workspace/executeCommand", {
-				command = "java.project.getClasspaths",
-				arguments = { base_dir_uri, vim.json.encode({ scope = "runtime" }) },
-			}, function(err, result)
-				if err then
-					runtime.set_error(err)
-				else
-					runtime.set(result.classpaths)
-				end
-			end, bufnr)
+			-- vim.schedule moves the LSP request out of any fast-event context
+			-- (nio coroutines run as libuv callbacks) so nvim_buf_is_valid,
+			-- called internally by client:request, is safe to invoke. Mirrors
+			-- the fix applied to command/binaries.lua in 7cdd189.
+			vim.schedule(function()
+				client:request("workspace/executeCommand", {
+					command = "java.project.getClasspaths",
+					arguments = { base_dir_uri, vim.json.encode({ scope = "runtime" }) },
+				}, function(err, result)
+					if err then
+						runtime.set_error(err)
+					else
+						runtime.set(result.classpaths)
+					end
+				end, bufnr)
 
-			client:request("workspace/executeCommand", {
-				command = "java.project.getClasspaths",
-				arguments = { base_dir_uri, vim.json.encode({ scope = "test" }) },
-			}, function(err, result)
-				if err then
-					test.set_error(err)
-				else
-					test.set(result.classpaths)
-				end
-			end, bufnr)
+				client:request("workspace/executeCommand", {
+					command = "java.project.getClasspaths",
+					arguments = { base_dir_uri, vim.json.encode({ scope = "test" }) },
+				}, function(err, result)
+					if err then
+						test.set_error(err)
+					else
+						test.set(result.classpaths)
+					end
+				end, bufnr)
+			end)
 
 			local additional_classpath_entries_strings = vim
 				--

--- a/tests/unit/test_classpath_provider_spec.lua
+++ b/tests/unit/test_classpath_provider_spec.lua
@@ -7,11 +7,15 @@ local async = require("tests.async_helpers").async
 local ClasspathProvider = require("neotest-java.core.spec_builder.compiler.classpath_provider")
 
 describe("Classpath Provider", function()
+	local sync_schedule = function(fn)
+		fn()
+	end
 	it(
 		"works",
 		async(function()
 			local base_dir = Path("some")
 			local classpath_provider = ClasspathProvider({
+				schedule = sync_schedule,
 				client_provider = function(base_dir_arg)
 					eq(base_dir, base_dir_arg)
 


### PR DESCRIPTION
Attempt to fix https://github.com/rcasia/neotest-java/issues/287

Disclosure: I'm new to neovim and I've run to an issue while running some of the tests. The fix is purely Claude generated and since I don't quite understand all the setup yet, I can't assess it's correctness quite well. From the referenced commit it look alright though and works on my machine. Feel free to close if you don't wish to have AI contributions, or suggest any improvements.

ClasspathProvider.get_classpath runs inside an nio coroutine. When the coroutine is resumed from a libuv callback, the body executes in a fast-event context. client:request internally calls nvim_buf_is_valid on the supplied bufnr, which is forbidden in fast context and raises E5560 on Neovim 0.12.

Wrap both client:request calls in vim.schedule so they always execute on the main loop. Mirrors the pattern already used in command/binaries.lua (7cdd189).