### PR TITLE
fix: include configured test class name patterns

### DIFF
--- a/lua/neotest-java/command/junit_command_builder.lua
+++ b/lua/neotest-java/command/junit_command_builder.lua
@@ -9,6 +9,7 @@
 --- @field _port number?
 --- @field _reports_dir neotest-java.Path
 --- @field _test_references neotest-java.TestReference[]
+--- @field _test_classname_patterns string[]
 --- @field _basedir neotest-java.Path
 --- @field _classpath_file_arg string
 --- @field _spring_property_filepaths neotest-java.Path[]
@@ -20,6 +21,7 @@ function CommandBuilder.new()
 	local fields = {
 		_jvm_args = {},
 		_test_references = {},
+		_test_classname_patterns = {},
 	}
 	return setmetatable(fields, CommandBuilder)
 end
@@ -63,6 +65,13 @@ function CommandBuilder:add_test_class(qualified_name)
 		qualified_name = qualified_name,
 		type = "class",
 	}
+	return self
+end
+
+--- @param patterns string[] | nil
+--- @return neotest-java.CommandBuilder
+function CommandBuilder:test_classname_patterns(patterns)
+	self._test_classname_patterns = patterns or {}
 	return self
 end
 
@@ -150,6 +159,12 @@ CommandBuilder.build_to_table = function(self)
 	end
 	assert(#selectors ~= 0, "junit command has to have a selector")
 
+	local include_classname_args = vim.iter(self._test_classname_patterns)
+		:map(function(pattern)
+			return "--include-classname=" .. quote_selector(pattern, is_debug_mode)
+		end)
+		:totable()
+
 	local additional_location_arg = vim
 		.iter(self._spring_property_filepaths)
 		--- @param path neotest-java.Path
@@ -174,6 +189,7 @@ CommandBuilder.build_to_table = function(self)
 			"-jar",
 			self._junit_jar:to_string(),
 			"execute",
+			include_classname_args,
 			"--classpath=" .. self._classpath_file_arg,
 			"--reports-dir=" .. self._reports_dir:to_string(),
 			"--fail-if-no-tests",

--- a/lua/neotest-java/core/spec_builder/init.lua
+++ b/lua/neotest-java/core/spec_builder/init.lua
@@ -43,7 +43,10 @@ local SpecBuilder = function(deps)
 			local project_type = deps.detect_project_type(root)
 			--- @type neotest-java.BuildTool
 			local build_tool = deps.build_tool_getter(project_type)
-			local command = CommandBuilder.new():junit_jar(config.junit_jar):jvm_args(config.jvm_args)
+			local command = CommandBuilder.new()
+				:junit_jar(config.junit_jar)
+				:jvm_args(config.jvm_args)
+				:test_classname_patterns(config.test_classname_patterns)
 			local project = assert(
 				Project.from_dirs_and_project_file(deps.scan(root), build_tool.get_project_filename(), build_tool),
 				"project not detected correctly"

--- a/tests/unit/test_junit_command_builder_spec.lua
+++ b/tests/unit/test_junit_command_builder_spec.lua
@@ -79,4 +79,27 @@ describe("JUnitCommandBuilder", function()
 			"expected --exclude-engine=archunit in command args"
 		)
 	end)
+
+	it("adds include classname filters", function()
+		local tree = {
+			data = function()
+				return { type = "namespace", id = "com.example.ExampleIT" }
+			end,
+			iter = function()
+				return ipairs({})
+			end,
+		}
+
+		local command = base_builder()
+			:test_classname_patterns({ "^.*Tests?$", "^.*IT$" })
+			:add_test_references_from_tree(tree)
+			:build_to_table()
+
+		assert(vim.iter(command.args):any(function(arg)
+			return arg == "--include-classname='^.*Tests?$'"
+		end))
+		assert(vim.iter(command.args):any(function(arg)
+			return arg == "--include-classname='^.*IT$'"
+		end))
+	end)
 end)

--- a/tests/unit/test_spec_builder_spec.lua
+++ b/tests/unit/test_spec_builder_spec.lua
@@ -10,6 +10,7 @@ local eq = assertions.eq
 describe("SpecBuilder", function()
 	local config = {
 		junit_jar = Path("my-junit-jar.jar"),
+		test_classname_patterns = { "^.*Tests?$", "^.*IT$" },
 	}
 	it("builds a spec for two test methods", function()
 		local path = Path("/user/home/root/src/test/java/com/example/Test.java")
@@ -83,6 +84,8 @@ describe("SpecBuilder", function()
 				"-jar",
 				"my-junit-jar.jar",
 				"execute",
+				"--include-classname='^.*Tests?$'",
+				"--include-classname='^.*IT$'",
 				"--classpath=classpath-file-argument",
 				"--reports-dir=report_folder",
 				"--fail-if-no-tests",


### PR DESCRIPTION
This fixes two problems:

1. Fix a problem where integration tests classes sufixed as *IT.java had its tests parsed correctly by treesitter, but not found by junit console since Junit Classname default is `^(Test.*|.+[.$]Test.*|.*Tests?)$` as you can see here: https://docs.junit.org/6.0.3/running-tests/console-launcher.html#options-discovering-tests
2. Fix a bug during result parse containing '>' sign.

All suggestions are welcome.