### PR TITLE
fix(positions_discoverer): inject parse_positions to avoid getenv in fast events

### DIFF
--- a/lua/neotest-java/core/positions_discoverer.lua
+++ b/lua/neotest-java/core/positions_discoverer.lua
@@ -75,12 +75,15 @@ end
 
 --- @class neotest-java.PositionsDiscoverer.Dependencies
 --- @field method_id_resolver neotest-java.MethodIdResolver
+--- @field parse_positions? fun(file_path: string, query: string, opts: table): neotest.Tree | any
 
 local PositionsDiscoverer = {}
 
 --- @param deps neotest-java.PositionsDiscoverer.Dependencies
 --- @return neotest-java.PositionsDiscoverer
 local function create_positions_discoverer(deps)
+	deps = deps or {}
+	local parse_positions = deps.parse_positions or lib.treesitter.parse_positions
 	local annotations = { "Test", "ParameterizedTest", "TestFactory", "CartesianTest" }
 	local a = vim.iter(annotations)
 		:map(function(v)
@@ -122,7 +125,7 @@ local function create_positions_discoverer(deps)
 		---@param file_path string Absolute file path
 		---@return neotest.Tree | nil
 		discover_positions = function(file_path)
-			local tree = lib.treesitter.parse_positions(file_path, query, {
+			local tree = parse_positions(file_path, query, {
 				require_namespaces = true,
 				nested_tests = false,
 				build_position = "require('neotest-java.core.positions_discoverer').build_position",

--- a/tests/unit/test_positions_discoverer_spec.lua
+++ b/tests/unit/test_positions_discoverer_spec.lua
@@ -3,6 +3,7 @@ local _ = require("vim.treesitter") -- NOTE: needed for loading treesitter upfro
 
 local assertions = require("tests.assertions")
 local async = require("tests.async_helpers").async
+local lib = require("neotest.lib")
 
 local eq = assertions.eq
 local PositionsDiscoverer = require("neotest-java.core.positions_discoverer")
@@ -25,6 +26,25 @@ local function remove_ref_field(tbl)
 	return result
 end
 
+-- Wrapper around parse_positions that avoids getenv in fast event contexts.
+-- Newer Neovim versions restrict getenv in coroutines, which breaks filetype
+-- detection. This wrapper returns "java" for .java files without calling getenv.
+local function safe_parse_positions(file_path, query, opts)
+	local original_detect = lib.files.detect_filetype
+	lib.files.detect_filetype = function(path)
+		if path:match("%.java$") then
+			return "java"
+		end
+		return original_detect(path)
+	end
+	local ok, result = pcall(lib.treesitter.parse_positions, file_path, query, opts)
+	lib.files.detect_filetype = original_detect
+	if not ok then
+		error(result)
+	end
+	return result
+end
+
 describe("PositionsDiscoverer", function()
 	local tmp_files
 	--- @type neotest-java.PositionsDiscoverer
@@ -38,6 +58,7 @@ describe("PositionsDiscoverer", function()
 					return method_id
 				end,
 			},
+			parse_positions = safe_parse_positions,
 		})
 	end)
 


### PR DESCRIPTION
## Problem

The CI pipeline was failing on Neovim nightly builds with the error:

```
E5560: Vimscript function "getenv" must not be called in a fast event context
```

This affected 4 tests in `test_positions_discoverer_spec.lua`.

## Root Cause

Newer Neovim versions (around `v0.13.0-dev-1103+`) restrict calling `getenv` in fast event contexts. When async tests call `lib.treesitter.parse_positions`, neotest's filetype detection internally calls `getenv`, which fails in the coroutine context.

## Solution

Inject `parse_positions` as a dependency into `PositionsDiscoverer` following the codebase's dependency injection pattern. Tests can now provide a wrapper that bypasses the `getenv` restriction for `.java` files by patching `detect_filetype` to return "java" directly.

## Changes

- `lua/neotest-java/core/positions_discoverer.lua`: Added `parse_positions` as an optional injectable dependency
- `tests/unit/test_positions_discoverer_spec.lua`: Test injects a `safe_parse_positions` wrapper that handles the filetype detection without calling `getenv`

This scopes the workaround to the specific test rather than globally monkey-patching in `minimal_init.lua`.

## Verification

All tests pass locally:
- `make test` ✓
- `stylua --check .` ✓
- `luacheck lua/neotest-java/` ✓
- `lua-language-server --check .` ✓