### PR TITLE
fix(positions_discoverer): apply getenv workaround to production code

### DIFF
--- a/lua/neotest-java/core/positions_discoverer.lua
+++ b/lua/neotest-java/core/positions_discoverer.lua
@@ -79,11 +79,34 @@ end
 
 local PositionsDiscoverer = {}
 
+--- Wrapper around parse_positions that avoids getenv in fast event contexts.
+--- Newer Neovim versions restrict getenv in coroutines, which breaks filetype
+--- detection. This wrapper returns "java" for .java files without calling getenv.
+--- @param file_path string
+--- @param query string
+--- @param opts table
+--- @return neotest.Tree | any
+local function safe_parse_positions(file_path, query, opts)
+	local original_detect = lib.files.detect_filetype
+	lib.files.detect_filetype = function(path)
+		if path:match("%.java$") then
+			return "java"
+		end
+		return original_detect(path)
+	end
+	local ok, result = pcall(lib.treesitter.parse_positions, file_path, query, opts)
+	lib.files.detect_filetype = original_detect
+	if not ok then
+		error(result)
+	end
+	return result
+end
+
 --- @param deps neotest-java.PositionsDiscoverer.Dependencies
 --- @return neotest-java.PositionsDiscoverer
 local function create_positions_discoverer(deps)
 	deps = deps or {}
-	local parse_positions = deps.parse_positions or lib.treesitter.parse_positions
+	local parse_positions = deps.parse_positions or safe_parse_positions
 	local annotations = { "Test", "ParameterizedTest", "TestFactory", "CartesianTest" }
 	local a = vim.iter(annotations)
 		:map(function(v)


### PR DESCRIPTION
## Follow-up to #310

The previous PR only fixed the test environment by injecting a wrapper, but production code still called `lib.treesitter.parse_positions` directly, which would fail in Neovim nightly for real users.

## Changes

- Move `safe_parse_positions` wrapper into production code as the default
- Still allow injection via `parse_positions` dependency for testing
- E2E tests verify the fix works in real usage

## Verification

- `make test` ✓
- `make test-e2e` ✓  
- `stylua --check .` ✓
- `luacheck lua/neotest-java/` ✓
- `lua-language-server --check .` ✓